### PR TITLE
Add missing groupNames to IEmojiPickerProps

### DIFF
--- a/emoji-picker-react.d.ts
+++ b/emoji-picker-react.d.ts
@@ -32,6 +32,7 @@ declare module 'emoji-picker-react' {
     disableAutoFocus?: boolean;
     disableSearchBar?: boolean;
     disableSkinTonePicker?: boolean;
+    groupNames?: Record<string, string>;
   }
 
   const EmojiPicker: React.FC<IEmojiPickerProps> = (


### PR DESCRIPTION
Add missing `groupNames` prop to `IEmojiPickerProps` to avoid TypeScript error. Closes #160 