### PR TITLE
Make MouseEvent a React.MouseEvent

### DIFF
--- a/emoji-picker-react.d.ts
+++ b/emoji-picker-react.d.ts
@@ -25,7 +25,7 @@ declare module 'emoji-picker-react' {
   }
 
   export interface IEmojiPickerProps {
-    onEmojiClick: (event: MouseEvent, data: IEmojiData) => void;
+    onEmojiClick: (event: React.MouseEvent, data: IEmojiData) => void;
     emojiUrl?: string;
     preload?: boolean;
     skinTone?: SkinTones;


### PR DESCRIPTION
Currently, MouseEvent is ambiguously inferred to either be React.MouseEvent or the browser's MouseEvent. This should get rid of the ambiguity