### PR TITLE
export SkinTones type

### DIFF
--- a/emoji-picker-react.d.ts
+++ b/emoji-picker-react.d.ts
@@ -8,7 +8,7 @@ declare module 'emoji-picker-react' {
   export const SKIN_TONE_MEDIUM_DARK = '1f3ff';
   export const SKIN_TONE_DARK = '1f3fd';
 
-  type SkinTones =
+  export type SkinTones =
     | typeof SKIN_TONE_NEUTRAL
     | typeof SKIN_TONE_LIGHT
     | typeof SKIN_TONE_MEDIUM_LIGHT


### PR DESCRIPTION
When trying to use the value of IEmojiData.activeSkinTone in TS, was not
able to access this type information. Added simple export of the
SkinTones type so could be imported and used.