### PR TITLE
docs: add Vite project troubleshooting info

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,27 @@ The complete list of keys is:
 ## UI Customizations
 
 In general, UI customizations can be done directly via CSS. Descriptive classnames were added in order for you to be able to easily target whatever it is you want to change, and the markup is guaranteed to stay unchanged until the next major version (4).
+
+## How to use in vite project
+
+### step1. Install rollup-plugin-node-polyfills to polyfill
+
+```shell
+$ npm install --save-dev rollup-plugin-node-polyfills
+```
+
+```shell
+$ yarn add rollup-plugin-node-polyfills -D
+```
+
+### step2. Configure vite.config.ts
+
+```ts
+// vite.config.ts
+import nodePolyfills from 'rollup-plugin-node-polyfills';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [nodePolyfills({ include: ['emoji-picker-react'] })],
+});
+```

--- a/README.md
+++ b/README.md
@@ -208,24 +208,12 @@ In general, UI customizations can be done directly via CSS. Descriptive classnam
 
 ## How to use in vite project
 
-### step1. Install rollup-plugin-node-polyfills to polyfill
+For reference, if you only need to shim global, you can add
 
-```shell
-$ npm install --save-dev rollup-plugin-node-polyfills
+```html
+<script>
+  window.global = window;
+</script>
 ```
 
-```shell
-$ yarn add rollup-plugin-node-polyfills -D
-```
-
-### step2. Configure vite.config.ts
-
-```ts
-// vite.config.ts
-import nodePolyfills from 'rollup-plugin-node-polyfills';
-
-// https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [nodePolyfills({ include: ['emoji-picker-react'] })],
-});
-```
+to your index.html

--- a/README.md
+++ b/README.md
@@ -206,7 +206,9 @@ The complete list of keys is:
 
 In general, UI customizations can be done directly via CSS. Descriptive classnames were added in order for you to be able to easily target whatever it is you want to change, and the markup is guaranteed to stay unchanged until the next major version (4).
 
-## How to use in vite project
+# Troubleshooting
+
+## How to use in Vite project
 
 For reference, if you only need to shim global, you can add
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
   externals: {
     react: 'react',
   },
+  target: 'node',
   output: {
     path: path.join(__dirname, 'dist'),
     filename: 'index.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,6 @@ module.exports = {
   externals: {
     react: 'react',
   },
-  target: 'node',
   output: {
     path: path.join(__dirname, 'dist'),
     filename: 'index.js',


### PR DESCRIPTION
You can try to release a beta version to let me in vite
This method is tested in the project, because it seems that Vite's analysis of modules is not the same. I am comparing https://github.com/Spencer17x/fiora-ui-react to modify the webpack configuration, but without sending the npm package, I cannot verify whether the issue is resolved. So I need to trouble you to release a beta version for me to test.