### PR TITLE
add missing searchPlaceholder type and proptype

### DIFF
--- a/emoji-picker-react.d.ts
+++ b/emoji-picker-react.d.ts
@@ -36,6 +36,7 @@ declare module 'emoji-picker-react' {
     groupNames?: Record<string, string>;
     groupVisibility?: Record<string, boolean>;
     native?: boolean;
+    searchPlaceholder?: string
   }
 
   const EmojiPicker: React.FC<IEmojiPickerProps>;

--- a/src/lib/propTypes/index.js
+++ b/src/lib/propTypes/index.js
@@ -39,6 +39,7 @@ export const configPropTypes = {
   disableAutoFocus: PropTypes.bool,
   disableSearchBar: PropTypes.bool,
   disableSkinTonePicker: PropTypes.bool,
+  searchPlaceholder: PropTypes.string
 };
 
 export const customEmojiPropTypes = {


### PR DESCRIPTION
closes https://github.com/ealush/emoji-picker-react/issues/251