### PR TITLE
Export SuggestionMode type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,8 @@ export {
   SkinTones,
   Theme,
   Categories,
-  EmojiClickData
+  EmojiClickData,
+  SuggestionMode
 } from './types/exposedTypes';
 
 export interface Props extends PickerConfig {}


### PR DESCRIPTION
Couldn't access the SuggestionMode enum directly from the exposedTypes src, added an export for it in index.