### PR TITLE
Support showEmoji predicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.3.0",
+  "version": "4.4.0-rc.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,5 @@
 import { GetEmojiUrl } from '../components/emoji/Emoji';
+import { DataEmoji } from '../dataUtils/DataTypes';
 import { emojiUrlByUnified } from '../dataUtils/emojiSelectors';
 import {
   EmojiClickData,
@@ -58,6 +59,7 @@ export function basePickerConfig(): PickerConfigInternal {
       ...basePreviewConfig
     },
     searchPlaceHolder: 'Search',
+    showEmoji: undefined,
     skinTonesDisabled: false,
     suggestedEmojisMode: SuggestionMode.FREQUENT,
     theme: Theme.LIGHT,
@@ -81,6 +83,7 @@ export type PickerConfigInternal = {
   height: PickerDimensions;
   width: PickerDimensions;
   getEmojiUrl: GetEmojiUrl;
+  showEmoji: undefined | ((emoji: DataEmoji) => boolean);
 };
 
 export type PreviewConfig = {

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -1,5 +1,6 @@
 import { isSystemDarkTheme } from '../DomUtils/isDarkTheme';
 import { usePickerConfig } from '../components/context/PickerConfigContext';
+import { DataEmoji } from '../dataUtils/DataTypes';
 import {
   EmojiClickData,
   EmojiStyle,
@@ -93,6 +94,13 @@ export function useGetEmojiUrlConfig(): (
 ) => string {
   const { getEmojiUrl } = usePickerConfig();
   return getEmojiUrl;
+}
+
+export function useShowEmojiConfig():
+  | undefined
+  | ((emoji: DataEmoji) => boolean) {
+  const { showEmoji } = usePickerConfig();
+  return showEmoji;
 }
 
 function getDimension(dimensionConfig: PickerDimensions): PickerDimensions {

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -1,15 +1,16 @@
 import { scrollTo } from '../DomUtils/scrollTo';
 import {
   usePickerMainRef,
-  useSearchInputRef,
+  useSearchInputRef
 } from '../components/context/ElementRefContext';
 import {
   FilterState,
   useFilterRef,
-  useSearchTermState,
+  useSearchTermState
 } from '../components/context/PickerContext';
 import { DataEmoji } from '../dataUtils/DataTypes';
 import { emojiNames } from '../dataUtils/emojiSelectors';
+import isFunction from '../predicates/isFunction';
 
 import { useFocusSearchInput } from './useFocus';
 
@@ -19,7 +20,7 @@ function useSetFilterRef() {
   return function setFilter(
     setter: FilterState | ((current: FilterState) => FilterState)
   ): void {
-    if (typeof setter === 'function') {
+    if (isFunction(setter)) {
       return setFilter(setter(filterRef.current));
     }
 
@@ -67,7 +68,7 @@ export function useFilter() {
   return {
     onChange,
     searchTerm,
-    SearchInputRef,
+    SearchInputRef
   };
 
   function onChange(inputValue: string) {
@@ -87,9 +88,9 @@ export function useFilter() {
       return applySearch(nextValue);
     }
 
-    setFilterRef((current) =>
+    setFilterRef(current =>
       Object.assign(current, {
-        [nextValue]: filterEmojiObjectByKeyword(longestMatch, nextValue),
+        [nextValue]: filterEmojiObjectByKeyword(longestMatch, nextValue)
       })
     );
     applySearch(nextValue);
@@ -129,14 +130,14 @@ function filterEmojiObjectByKeyword(
 }
 
 function hasMatch(emoji: DataEmoji, keyword: string): boolean {
-  return emojiNames(emoji).some((name) => name.includes(keyword));
+  return emojiNames(emoji).some(name => name.includes(keyword));
 }
 
 export function useIsEmojiFiltered(): (unified: string) => boolean {
   const { current: filter } = useFilterRef();
   const [searchTerm] = useSearchTermState();
 
-  return (unified) => isEmojiFilteredBySearchTerm(unified, filter, searchTerm);
+  return unified => isEmojiFilteredBySearchTerm(unified, filter, searchTerm);
 }
 
 function isEmojiFilteredBySearchTerm(
@@ -167,7 +168,7 @@ function findLongestMatch(
 
   const longestMatchingKey = Object.keys(dict)
     .sort((a, b) => b.length - a.length)
-    .find((key) => keyword.includes(key));
+    .find(key => keyword.includes(key));
 
   if (longestMatchingKey) {
     return dict[longestMatchingKey];

--- a/src/predicates/isFunction.ts
+++ b/src/predicates/isFunction.ts
@@ -1,0 +1,5 @@
+export default function isFunction(
+  value: any
+): value is (...args: any[]) => any {
+  return typeof value === 'function';
+}

--- a/stories/picker.stories.tsx
+++ b/stories/picker.stories.tsx
@@ -9,6 +9,7 @@ import EmojiPicker, {
   Theme
 } from '../src';
 import { Categories } from '../src/config/categoryConfig';
+import { DataEmoji } from '../src/dataUtils/DataTypes';
 import { SuggestionMode } from '../src/types/exposedTypes';
 
 const meta: Meta = {
@@ -76,6 +77,13 @@ export const CustomSearchPlaceholder = (args: Props) => (
 );
 export const SkinTonesDisabled = (args: Props) => (
   <Template {...args} skinTonesDisabled />
+);
+
+export const ShowEmoji = (args: Props) => (
+  <Template
+    {...args}
+    showEmoji={(emoji: DataEmoji) => emoji.n.join('').includes('clown')}
+  />
 );
 export const AlternativeDefaultSkinTone = (args: Props) => (
   <Template {...args} defaultSkinTone={SkinTones.MEDIUM} />


### PR DESCRIPTION
Allow for passing a `showEmoji` property that takes a predicate function. When returning false, the emoji will be removed from the picker, for example:
```
<Picker showEmoji={(emoji) => !!myAllowedEmojes[emoji.u]}/>
```