### PR TITLE
Add disable search bar prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,22 +43,24 @@ function App() {
 
 The following props are accepted by them picker:
 
-| Prop                | Type              | Default    | Description                                                                                                                                |
-| ------------------- | ----------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| onEmojiClick        | function          |            | Callback function that is called when an emoji is clicked. The function receives the emoji object as a parameter.                          |
-| autoFocusSearch     | boolean           | `true`     | Controls the auto focus of the search input.                                                                                               |
-| Theme               | string            | `light`    | Controls the theme of the picker. Possible values are `light`, `dark` and `auto`.                                                          |
-| emojiStyle          | string            | `apple`    | Controls the emoji style. Possible values are `google`, `apple`, `facebook`, `twitter` and `native`.                                       |
-| defaultSkinTone     | string            | `neutral`  | Controls the default skin tone.                                                                                                            |
-| lazyLoadEmojis      | boolean           | `false`    | Controls whether the emojis are loaded lazily or not.                                                                                      |
-| previewConfig       | object            | `{}`       | Controls the preview of the emoji. See below for more information.                                                                         |
-| searchPlaceholder   | string            | `Search`   | Controls the placeholder of the search input.                                                                                              |
-| suggestedEmojisMode | string            | `frequent` | Controls the suggested emojis mode. Possible values are `frequent` and `recent`.                                                           |
-| skinTonesDisabled   | boolean           | `false`    | Controls whether the skin tones are disabled or not.                                                                                       |
-| `width`             | `number`/`string` | `350`      | Controls the width of the picker. You can provide a number that will be treated as pixel size, or your any accepted css width as string.   |
-| emojiVersion        | `string`          | -          | Allows displaying emojis up to a certain version for compatibility.                                                                        |
-| `height`            | `number`/`string` | `450`      | Controls the height of the picker. You can provide a number that will be treated as pixel size, or your any accepted css height as string. |
-| getEmojiUrl         | `Function`        | -          | Allows to customize the emoji url and provide your own image host.                                                                         |
+| Prop                   | Type              | Default    | Description                                                                                                                                |
+| ---------------------- | ----------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| onEmojiClick           | function          |            | Callback function that is called when an emoji is clicked. The function receives the emoji object as a parameter.                          |
+| autoFocusSearch        | boolean           | `true`     | Controls the auto focus of the search input.                                                                                               |
+| Theme                  | string            | `light`    | Controls the theme of the picker. Possible values are `light`, `dark` and `auto`.                                                          |
+| emojiStyle             | string            | `apple`    | Controls the emoji style. Possible values are `google`, `apple`, `facebook`, `twitter` and `native`.                                       |
+| defaultSkinTone        | string            | `neutral`  | Controls the default skin tone.                                                                                                            |
+| lazyLoadEmojis         | boolean           | `false`    | Controls whether the emojis are loaded lazily or not.                                                                                      |
+| previewConfig          | object            | `{}`       | Controls the preview of the emoji. See below for more information.                                                                         |
+| searchPlaceholder      | string            | `Search`   | Controls the placeholder of the search input.                                                                                              |
+| suggestedEmojisMode    | string            | `frequent` | Controls the suggested emojis mode. Possible values are `frequent` and `recent`.                                                           |
+| skinTonesDisabled      | boolean           | `false`    | Controls whether the skin tones are disabled or not.                                                                                       |
+| searchDisabled         | boolean           | `false`    | Controls whether the search is disabled or not. When disabled, the skin tone picker will be shown in the preview component.                |
+| skinTonePickerLocation | string            | `SEARCH`   | Controls the location of the skin tone picker. Possible values are `SEARCH` and `PREVIEW`.                                                 |
+| `width`                | `number`/`string` | `350`      | Controls the width of the picker. You can provide a number that will be treated as pixel size, or your any accepted css width as string.   |
+| emojiVersion           | `string`          | -          | Allows displaying emojis up to a certain version for compatibility.                                                                        |
+| `height`               | `number`/`string` | `450`      | Controls the height of the picker. You can provide a number that will be treated as pixel size, or your any accepted css height as string. |
+| getEmojiUrl            | `Function`        | -          | Allows to customize the emoji url and provide your own image host.                                                                         |
 
 ## Full details
 
@@ -108,7 +110,15 @@ The skin tones typescript enum can be imported directly from the package:
 import { SkinTones } from 'emoji-picker-react';
 ```
 
+- `searchDisabled`: `boolean` - Whether to disable the search input. Defaults to `false`. When disabled, the skin tone picker will be shown in the preview component.
+
 - `skinTonesDisabled`: `boolean` - Whether to disable the skin tone selection. Defaults to `false`.
+
+- `skinTonePickerLocation`: `SkinTonePickerLocation` - The location of the skin tone picker. Can be either `SEARCH` or `PREVIEW`. Defaults to `SEARCH`. The `SkinTonePickerLocation` enum can be imported from the package.
+
+  ```ts
+  import { SkinTonePickerLocation } from 'emoji-picker-react';
+  ```
 
 - `previewConfig`: `PreviewConfig` - Full control over the Preview component, either to show/hide it, change the default emoji or the default caption.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.3.0",
+  "version": "4.4.0-rc.2",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/DomUtils/classNames.ts
+++ b/src/DomUtils/classNames.ts
@@ -13,7 +13,9 @@ export enum ClassNames {
   emojiList = 'epr-emoji-list',
   external = '__EmojiPicker__',
   emojiPicker = 'EmojiPickerReact',
-  open = 'epr-open'
+  open = 'epr-open',
+  vertical = 'epr-vertical',
+  horizontal = 'epr-horizontal'
 }
 
 export function asSelectors(...classNames: ClassNames[]): string {

--- a/src/DomUtils/classNames.ts
+++ b/src/DomUtils/classNames.ts
@@ -13,8 +13,9 @@ export enum ClassNames {
   emojiList = 'epr-emoji-list',
   external = '__EmojiPicker__',
   emojiPicker = 'EmojiPickerReact',
+  open = 'epr-open'
 }
 
 export function asSelectors(...classNames: ClassNames[]): string {
-  return classNames.map((c) => `.${c}`).join('');
+  return classNames.map(c => `.${c}`).join('');
 }

--- a/src/EmojiPickerReact.css
+++ b/src/EmojiPickerReact.css
@@ -7,6 +7,7 @@
   --epr-picker-border-color: #e7e7e7;
   --epr-bg-color: #fff;
   --epr-category-icon-active-color: #6aa8de;
+  --epr-skin-tone-picker-menu-color: #56565610;
 
   --epr-horizontal-padding: 10px;
 
@@ -67,6 +68,7 @@
   --epr-emoji-variations-indictator-z-index: 1;
   --epr-category-label-z-index: 2;
   --epr-skin-variation-picker-z-index: 5;
+  --epr-preview-z-index: 6;
 }
 
 .EmojiPickerReact.epr-dark-theme {

--- a/src/EmojiPickerReact.css
+++ b/src/EmojiPickerReact.css
@@ -7,7 +7,7 @@
   --epr-picker-border-color: #e7e7e7;
   --epr-bg-color: #fff;
   --epr-category-icon-active-color: #6aa8de;
-  --epr-skin-tone-picker-menu-color: #56565610;
+  --epr-skin-tone-picker-menu-color: #ffffff95;
 
   --epr-horizontal-padding: 10px;
 
@@ -85,6 +85,7 @@
   --epr-search-input-bg-color-active: var(--epr-dark);
   --epr-emoji-variation-indicator-color: #444;
   --epr-category-icon-active-color: #3271b7;
+  --epr-skin-tone-picker-menu-color: #22222295;
 }
 
 .EmojiPickerReact {

--- a/src/components/Layout/Absolute.tsx
+++ b/src/components/Layout/Absolute.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+type Props = Readonly<{
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}>;
+
+export default function Absolute({ children, className, style }: Props) {
+  return (
+    <div style={{ ...style, position: 'absolute' }} className={className}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/Layout/Relative.tsx
+++ b/src/components/Layout/Relative.tsx
@@ -3,11 +3,12 @@ import * as React from 'react';
 type Props = Readonly<{
   children: React.ReactNode;
   className?: string;
+  style?: React.CSSProperties;
 }>;
 
-export default function Relative({ children, className }: Props) {
+export default function Relative({ children, className, style }: Props) {
   return (
-    <div style={{ position: 'relative' }} className={className}>
+    <div style={{ ...style, position: 'relative' }} className={className}>
       {children}
     </div>
   );

--- a/src/components/Layout/Space.tsx
+++ b/src/components/Layout/Space.tsx
@@ -1,0 +1,11 @@
+import clsx from 'clsx';
+import * as React from 'react';
+
+type Props = Readonly<{
+  className?: string;
+  style?: React.CSSProperties;
+}>;
+
+export default function Space({ className, style = {} }: Props) {
+  return <div style={{ flex: 1, ...style }} className={clsx(className)} />;
+}

--- a/src/components/footer/Preview.css
+++ b/src/components/footer/Preview.css
@@ -5,6 +5,7 @@
   border-top: 1px solid var(--epr-preview-border-color);
   height: var(--epr-preview-height);
   position: relative;
+  z-index: var(--epr-preview-z-index);
 }
 
 .EmojiPickerReact .epr-preview .epr-preview-emoji-label {

--- a/src/components/footer/Preview.css
+++ b/src/components/footer/Preview.css
@@ -4,6 +4,7 @@
   align-items: center;
   border-top: 1px solid var(--epr-preview-border-color);
   height: var(--epr-preview-height);
+  position: relative;
 }
 
 .EmojiPickerReact .epr-preview .epr-preview-emoji-label {

--- a/src/components/footer/Preview.tsx
+++ b/src/components/footer/Preview.tsx
@@ -14,9 +14,11 @@ import {
 } from '../../dataUtils/emojiSelectors';
 import { useEmojiPreviewEvents } from '../../hooks/useEmojiPreviewEvents';
 import Flex from '../Layout/Flex';
+import Space from '../Layout/Space';
 import { useEmojiVariationPickerState } from '../context/PickerContext';
 import { ViewOnlyEmoji } from '../emoji/Emoji';
 import './Preview.css';
+import { SkinTonePicker } from '../header/SkinTonePicker';
 
 export function Preview() {
   const previewConfig = usePreviewConfig();
@@ -28,6 +30,8 @@ export function Preview() {
   return (
     <Flex className="epr-preview">
       <PreviewBody />
+      <Space />
+      <SkinTonePicker expands={false} />
     </Flex>
   );
 }

--- a/src/components/footer/Preview.tsx
+++ b/src/components/footer/Preview.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useState } from 'react';
 
-import { SkinTonePickerLocation } from '../../config/config';
 import {
   useEmojiStyleConfig,
   useGetEmojiUrlConfig,
@@ -14,7 +13,7 @@ import {
   emojiUnified
 } from '../../dataUtils/emojiSelectors';
 import { useEmojiPreviewEvents } from '../../hooks/useEmojiPreviewEvents';
-import { useShouldShowSkinTonePicker } from '../../hooks/useShouldShowSkinTonePicker';
+import { useIsSkinToneInPreview } from '../../hooks/useShouldShowSkinTonePicker';
 import Flex from '../Layout/Flex';
 import Space from '../Layout/Space';
 import { useEmojiVariationPickerState } from '../context/PickerContext';
@@ -24,7 +23,7 @@ import { SkinTonePickerMenu } from '../header/SkinTonePicker';
 
 export function Preview() {
   const previewConfig = usePreviewConfig();
-  const shouldShowSkinTonePicker = useShouldShowSkinTonePicker();
+  const isSkinToneInPreview = useIsSkinToneInPreview();
 
   if (!previewConfig.showPreview) {
     return null;
@@ -34,9 +33,7 @@ export function Preview() {
     <Flex className="epr-preview">
       <PreviewBody />
       <Space />
-      {shouldShowSkinTonePicker(SkinTonePickerLocation.PREVIEW) ? (
-        <SkinTonePickerMenu />
-      ) : null}
+      {isSkinToneInPreview ? <SkinTonePickerMenu /> : null}
     </Flex>
   );
 }

--- a/src/components/footer/Preview.tsx
+++ b/src/components/footer/Preview.tsx
@@ -18,7 +18,7 @@ import Space from '../Layout/Space';
 import { useEmojiVariationPickerState } from '../context/PickerContext';
 import { ViewOnlyEmoji } from '../emoji/Emoji';
 import './Preview.css';
-import { SkinTonePicker } from '../header/SkinTonePicker';
+import { SkinTonePickerMenu } from '../header/SkinTonePicker';
 
 export function Preview() {
   const previewConfig = usePreviewConfig();
@@ -31,7 +31,7 @@ export function Preview() {
     <Flex className="epr-preview">
       <PreviewBody />
       <Space />
-      <SkinTonePicker expands={false} />
+      <SkinTonePickerMenu />
     </Flex>
   );
 }

--- a/src/components/footer/Preview.tsx
+++ b/src/components/footer/Preview.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useState } from 'react';
 
+import { SkinTonePickerLocation } from '../../config/config';
 import {
   useEmojiStyleConfig,
   useGetEmojiUrlConfig,
@@ -13,6 +14,7 @@ import {
   emojiUnified
 } from '../../dataUtils/emojiSelectors';
 import { useEmojiPreviewEvents } from '../../hooks/useEmojiPreviewEvents';
+import { useShouldShowSkinTonePicker } from '../../hooks/useShouldShowSkinTonePicker';
 import Flex from '../Layout/Flex';
 import Space from '../Layout/Space';
 import { useEmojiVariationPickerState } from '../context/PickerContext';
@@ -22,6 +24,7 @@ import { SkinTonePickerMenu } from '../header/SkinTonePicker';
 
 export function Preview() {
   const previewConfig = usePreviewConfig();
+  const shouldShowSkinTonePicker = useShouldShowSkinTonePicker();
 
   if (!previewConfig.showPreview) {
     return null;
@@ -31,7 +34,9 @@ export function Preview() {
     <Flex className="epr-preview">
       <PreviewBody />
       <Space />
-      <SkinTonePickerMenu />
+      {shouldShowSkinTonePicker(SkinTonePickerLocation.PREVIEW) ? (
+        <SkinTonePickerMenu />
+      ) : null}
     </Flex>
   );
 }

--- a/src/components/footer/Preview.tsx
+++ b/src/components/footer/Preview.tsx
@@ -4,13 +4,13 @@ import { useState } from 'react';
 import {
   useEmojiStyleConfig,
   useGetEmojiUrlConfig,
-  usePreviewConfig,
+  usePreviewConfig
 } from '../../config/useConfig';
 import { asEmoji } from '../../dataUtils/asEmoji';
 import {
   emojiByUnified,
   emojiName,
-  emojiUnified,
+  emojiUnified
 } from '../../dataUtils/emojiSelectors';
 import { useEmojiPreviewEvents } from '../../hooks/useEmojiPreviewEvents';
 import Flex from '../Layout/Flex';
@@ -20,6 +20,20 @@ import './Preview.css';
 
 export function Preview() {
   const previewConfig = usePreviewConfig();
+
+  if (!previewConfig.showPreview) {
+    return null;
+  }
+
+  return (
+    <Flex className="epr-preview">
+      <PreviewBody />
+    </Flex>
+  );
+}
+
+export function PreviewBody() {
+  const previewConfig = usePreviewConfig();
   const [previewEmoji, setPreviewEmoji] = useState<PreviewEmoji>(null);
   const emojiStyle = useEmojiStyleConfig();
   const [variationPickerEmoji] = useEmojiVariationPickerState();
@@ -27,19 +41,11 @@ export function Preview() {
 
   useEmojiPreviewEvents(previewConfig.showPreview, setPreviewEmoji);
 
-  if (!previewConfig.showPreview) {
-    return null;
-  }
-
   const emoji = emojiByUnified(previewEmoji?.originalUnified);
 
   const show = emoji != null && previewEmoji != null;
 
-  return (
-    <Flex className="epr-preview">
-      <PreviewContent />
-    </Flex>
-  );
+  return <PreviewContent />;
 
   function PreviewContent() {
     const defaultEmoji = asEmoji(

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,20 +1,15 @@
 import * as React from 'react';
 
-import Flex from '../Layout/Flex';
 import Relative from '../Layout/Relative';
 import { CategoryNavigation } from '../navigation/CategoryNavigation';
 
-import { Search } from './Search';
-import { SkinTonePicker } from './SkinTonePicker';
 import './Header.css';
+import { SearchContainer } from './Search';
 
 export function Header() {
   return (
     <Relative className="epr-header">
-      <Flex className="epr-header-overlay">
-        <Search />
-        <SkinTonePicker />
-      </Flex>
+      <SearchContainer />
       <CategoryNavigation />
     </Relative>
   );

--- a/src/components/header/Search.tsx
+++ b/src/components/header/Search.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useState } from 'react';
 
 import { asSelectors, ClassNames } from '../../DomUtils/classNames';
+import { SkinTonePickerLocation } from '../../config/config';
 import {
   useAutoFocusSearchConfig,
   useSearchDisabledConfig,
@@ -14,6 +15,7 @@ import {
   useClearSearch,
   useFilter
 } from '../../hooks/useFilter';
+import { useShouldShowSkinTonePicker } from '../../hooks/useShouldShowSkinTonePicker';
 import Flex from '../Layout/Flex';
 import Relative from '../Layout/Relative';
 import { Button } from '../atoms/Button';
@@ -24,6 +26,7 @@ import { SkinTonePicker } from './SkinTonePicker';
 
 export function SearchContainer() {
   const searchDisabled = useSearchDisabledConfig();
+  const shouldShowSkinTonePicker = useShouldShowSkinTonePicker();
 
   if (searchDisabled) {
     return null;
@@ -32,7 +35,10 @@ export function SearchContainer() {
   return (
     <Flex className="epr-header-overlay">
       <Search />
-      <SkinTonePicker />
+
+      {shouldShowSkinTonePicker(SkinTonePickerLocation.SEARCH) ? (
+        <SkinTonePicker />
+      ) : null}
     </Flex>
   );
 }

--- a/src/components/header/Search.tsx
+++ b/src/components/header/Search.tsx
@@ -5,19 +5,37 @@ import { useState } from 'react';
 import { asSelectors, ClassNames } from '../../DomUtils/classNames';
 import {
   useAutoFocusSearchConfig,
-  useSearchPlaceHolderConfig,
+  useSearchDisabledConfig,
+  useSearchPlaceHolderConfig
 } from '../../config/useConfig';
 import { useCloseAllOpenToggles } from '../../hooks/useCloseAllOpenToggles';
 import {
   getNormalizedSearchTerm,
   useClearSearch,
-  useFilter,
+  useFilter
 } from '../../hooks/useFilter';
+import Flex from '../Layout/Flex';
 import Relative from '../Layout/Relative';
 import { Button } from '../atoms/Button';
 import { useSearchInputRef } from '../context/ElementRefContext';
 
 import './Search.css';
+import { SkinTonePicker } from './SkinTonePicker';
+
+export function SearchContainer() {
+  const searchDisabled = useSearchDisabledConfig();
+
+  if (searchDisabled) {
+    return null;
+  }
+
+  return (
+    <Flex className="epr-header-overlay">
+      <Search />
+      <SkinTonePicker />
+    </Flex>
+  );
+}
 
 export function Search() {
   const [inc, setInc] = useState(0);
@@ -42,7 +60,7 @@ export function Search() {
         className="epr-search"
         type="text"
         placeholder={placeholder}
-        onChange={(event) => {
+        onChange={event => {
           setInc(inc + 1);
           setTimeout(() => {
             onChange(event?.target?.value ?? value);

--- a/src/components/header/Search.tsx
+++ b/src/components/header/Search.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { useState } from 'react';
 
 import { asSelectors, ClassNames } from '../../DomUtils/classNames';
-import { SkinTonePickerLocation } from '../../config/config';
 import {
   useAutoFocusSearchConfig,
   useSearchDisabledConfig,
@@ -15,7 +14,7 @@ import {
   useClearSearch,
   useFilter
 } from '../../hooks/useFilter';
-import { useShouldShowSkinTonePicker } from '../../hooks/useShouldShowSkinTonePicker';
+import { useIsSkinToneInSearch } from '../../hooks/useShouldShowSkinTonePicker';
 import Flex from '../Layout/Flex';
 import Relative from '../Layout/Relative';
 import { Button } from '../atoms/Button';
@@ -26,7 +25,8 @@ import { SkinTonePicker } from './SkinTonePicker';
 
 export function SearchContainer() {
   const searchDisabled = useSearchDisabledConfig();
-  const shouldShowSkinTonePicker = useShouldShowSkinTonePicker();
+
+  const isSkinToneInSearch = useIsSkinToneInSearch();
 
   if (searchDisabled) {
     return null;
@@ -36,9 +36,7 @@ export function SearchContainer() {
     <Flex className="epr-header-overlay">
       <Search />
 
-      {shouldShowSkinTonePicker(SkinTonePickerLocation.SEARCH) ? (
-        <SkinTonePicker />
-      ) : null}
+      {isSkinToneInSearch ? <SkinTonePicker /> : null}
     </Flex>
   );
 }

--- a/src/components/header/SkinTonePicker.css
+++ b/src/components/header/SkinTonePicker.css
@@ -1,5 +1,5 @@
 .EmojiPickerReact .epr-skin-tones {
-  --epr-skin-tone-size: 16px;
+  --epr-skin-tone-size: 15px;
 }
 
 .EmojiPickerReact .epr-skin-tones {
@@ -7,7 +7,21 @@
   align-items: center;
   justify-content: flex-end;
   transition: all 0.3s ease-in-out;
-  background: var(--epr-bg-color);
+  padding: 10px 0;
+}
+
+.EmojiPickerReact .epr-skin-tones.epr-vertical {
+  padding: 5px;
+  align-items: flex-end;
+  flex-direction: column;
+  border-radius: 6px;
+  border: 1px solid var(--epr-bg-color);
+}
+
+.EmojiPickerReact .epr-skin-tones.epr-vertical.epr-open {
+  border: 1px solid var(--epr-picker-border-color);
+  backdrop-filter: blur(5px);
+  background: var(--epr-skin-tone-picker-menu-color);
 }
 
 .EmojiPickerReact .epr-skin-tone-select {
@@ -43,11 +57,11 @@
 }
 
 .EmojiPickerReact .epr-skin-tones .epr-tone:hover {
-  box-shadow: 0 0 0 5px var(--epr-active-skin-hover-color);
+  box-shadow: 0 0 0 3px var(--epr-active-skin-hover-color);
 }
 
 .EmojiPickerReact .epr-skin-tones .epr-tone:focus {
-  box-shadow: 0 0 0 5px var(--epr-focus-bg-color);
+  box-shadow: 0 0 0 3px var(--epr-focus-bg-color);
 }
 
 .EmojiPickerReact

--- a/src/components/header/SkinTonePicker.css
+++ b/src/components/header/SkinTonePicker.css
@@ -7,11 +7,7 @@
   align-items: center;
   justify-content: flex-end;
   transition: all 0.3s ease-in-out;
-  flex-basis: 30px;
-}
-
-.EmojiPickerReact .epr-skin-tones.open {
-  flex-basis: 170px;
+  background: var(--epr-bg-color);
 }
 
 .EmojiPickerReact .epr-skin-tone-select {
@@ -20,11 +16,11 @@
   height: var(--epr-skin-tone-size);
 }
 
-.EmojiPickerReact .epr-skin-tones.open .epr-tone {
+.EmojiPickerReact .epr-skin-tones.epr-open .epr-tone {
   transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
 }
 
-.EmojiPickerReact .epr-skin-tones:not(.open) .epr-tone {
+.EmojiPickerReact .epr-skin-tones:not(.epr-open) .epr-tone {
   z-index: 0;
   opacity: 0;
 }
@@ -55,7 +51,7 @@
 }
 
 .EmojiPickerReact
-  .epr-skin-tones.open
+  .epr-skin-tones.epr-open
   .epr-skin-tone-select
   .epr-tone.epr-active:after {
   content: '';

--- a/src/components/header/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker.tsx
@@ -18,7 +18,13 @@ import {
 } from '../context/PickerContext';
 import './SkinTonePicker.css';
 
-export function SkinTonePicker() {
+const FULL_SIZE = 28;
+
+type Props = Readonly<{
+  expands?: boolean;
+}>;
+
+export function SkinTonePicker({ expands = true }: Props = {}) {
   const SkinTonePickerRef = useSkinTonePickerRef();
   const isDisabled = useSkinTonesDisabledConfig();
   const [isOpen, setIsOpen] = useSkinToneFanOpenState();
@@ -30,11 +36,15 @@ export function SkinTonePicker() {
     return null;
   }
 
+  const flexBasis =
+    isOpen && expands
+      ? `${FULL_SIZE * skinToneVariations.length}px`
+      : FULL_SIZE + 'px';
+
   return (
     <Relative
-      className={clsx('epr-skin-tones', {
-        open: isOpen
-      })}
+      className={clsx('epr-skin-tones', { [ClassNames.open]: isOpen })}
+      style={{ flexBasis }}
     >
       <div className="epr-skin-tone-select" ref={SkinTonePickerRef}>
         {skinToneVariations.map((skinToneVariation, i) => {
@@ -43,7 +53,7 @@ export function SkinTonePicker() {
             <Button
               style={{
                 transform: clsx(
-                  `translateX(-${i * (isOpen ? 28 : 0)}px)`,
+                  `translateX(-${i * (isOpen ? FULL_SIZE : 0)}px)`,
                   isOpen && active && 'scale(1.3)'
                 )
               }}

--- a/src/components/header/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker.tsx
@@ -9,6 +9,7 @@ import skinToneVariations, {
 import { useCloseAllOpenToggles } from '../../hooks/useCloseAllOpenToggles';
 import { useFocusSearchInput } from '../../hooks/useFocus';
 import { SkinTones } from '../../types/exposedTypes';
+import Absolute from '../Layout/Absolute';
 import Relative from '../Layout/Relative';
 import { Button } from '../atoms/Button';
 import { useSkinTonePickerRef } from '../context/ElementRefContext';
@@ -18,13 +19,25 @@ import {
 } from '../context/PickerContext';
 import './SkinTonePicker.css';
 
-const FULL_SIZE = 28;
+const ITEM_SIZE = 28;
 
-type Props = Readonly<{
-  expands?: boolean;
-}>;
+type Props = {
+  direction?: SkinTonePickerDirection;
+};
 
-export function SkinTonePicker({ expands = true }: Props = {}) {
+export function SkinTonePickerMenu() {
+  return (
+    <Relative style={{ height: ITEM_SIZE }}>
+      <Absolute style={{ bottom: 0, right: 0 }}>
+        <SkinTonePicker direction={SkinTonePickerDirection.VERTICAL} />
+      </Absolute>
+    </Relative>
+  );
+}
+
+export function SkinTonePicker({
+  direction = SkinTonePickerDirection.HORIZONTAL
+}: Props) {
   const SkinTonePickerRef = useSkinTonePickerRef();
   const isDisabled = useSkinTonesDisabledConfig();
   const [isOpen, setIsOpen] = useSkinToneFanOpenState();
@@ -36,15 +49,22 @@ export function SkinTonePicker({ expands = true }: Props = {}) {
     return null;
   }
 
-  const flexBasis =
-    isOpen && expands
-      ? `${FULL_SIZE * skinToneVariations.length}px`
-      : FULL_SIZE + 'px';
+  const fullWidth = `${ITEM_SIZE * skinToneVariations.length}px`;
+
+  const expandedSize = isOpen ? fullWidth : ITEM_SIZE + 'px';
+
+  const vertical = direction === SkinTonePickerDirection.VERTICAL;
 
   return (
     <Relative
-      className={clsx('epr-skin-tones', { [ClassNames.open]: isOpen })}
-      style={{ flexBasis }}
+      className={clsx('epr-skin-tones', direction, {
+        [ClassNames.open]: isOpen
+      })}
+      style={
+        vertical
+          ? { flexBasis: expandedSize, height: expandedSize }
+          : { flexBasis: expandedSize }
+      }
     >
       <div className="epr-skin-tone-select" ref={SkinTonePickerRef}>
         {skinToneVariations.map((skinToneVariation, i) => {
@@ -53,7 +73,9 @@ export function SkinTonePicker({ expands = true }: Props = {}) {
             <Button
               style={{
                 transform: clsx(
-                  `translateX(-${i * (isOpen ? FULL_SIZE : 0)}px)`,
+                  vertical
+                    ? `translateY(-${i * (isOpen ? ITEM_SIZE : 0)}px)`
+                    : `translateX(-${i * (isOpen ? ITEM_SIZE : 0)}px)`,
                   isOpen && active && 'scale(1.3)'
                 )
               }}
@@ -81,4 +103,9 @@ export function SkinTonePicker({ expands = true }: Props = {}) {
       </div>
     </Relative>
   );
+}
+
+export enum SkinTonePickerDirection {
+  VERTICAL = ClassNames.vertical,
+  HORIZONTAL = ClassNames.horizontal
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -29,10 +29,15 @@ export function mergeConfig(
     suggestionMode: config.suggestedEmojisMode
   });
 
+  const skinTonePickerLocation = config.searchDisabled
+    ? SkinTonePickerLocation.PREVIEW
+    : config.skinTonePickerLocation;
+
   return {
     ...config,
     categories,
-    previewConfig
+    previewConfig,
+    skinTonePickerLocation
   };
 }
 
@@ -59,6 +64,7 @@ export function basePickerConfig(): PickerConfigInternal {
     },
     searchDisabled: false,
     searchPlaceHolder: 'Search',
+    skinTonePickerLocation: SkinTonePickerLocation.SEARCH,
     skinTonesDisabled: false,
     suggestedEmojisMode: SuggestionMode.FREQUENT,
     theme: Theme.LIGHT,
@@ -83,6 +89,7 @@ export type PickerConfigInternal = {
   width: PickerDimensions;
   getEmojiUrl: GetEmojiUrl;
   searchDisabled: boolean;
+  skinTonePickerLocation: SkinTonePickerLocation;
 };
 
 export type PreviewConfig = {
@@ -104,3 +111,8 @@ type ConfigExternal = {
 export type PickerConfig = Partial<ConfigExternal>;
 
 export type PickerDimensions = string | number;
+
+export enum SkinTonePickerLocation {
+  SEARCH = 'SEARCH',
+  PREVIEW = 'PREVIEW'
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -57,6 +57,7 @@ export function basePickerConfig(): PickerConfigInternal {
     previewConfig: {
       ...basePreviewConfig
     },
+    searchDisabled: false,
     searchPlaceHolder: 'Search',
     skinTonesDisabled: false,
     suggestedEmojisMode: SuggestionMode.FREQUENT,
@@ -81,6 +82,7 @@ export type PickerConfigInternal = {
   height: PickerDimensions;
   width: PickerDimensions;
   getEmojiUrl: GetEmojiUrl;
+  searchDisabled: boolean;
 };
 
 export type PreviewConfig = {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -3,6 +3,7 @@ import { emojiUrlByUnified } from '../dataUtils/emojiSelectors';
 import {
   EmojiClickData,
   EmojiStyle,
+  SkinTonePickerLocation,
   SkinTones,
   SuggestionMode,
   Theme
@@ -111,8 +112,3 @@ type ConfigExternal = {
 export type PickerConfig = Partial<ConfigExternal>;
 
 export type PickerDimensions = string | number;
-
-export enum SkinTonePickerLocation {
-  SEARCH = 'SEARCH',
-  PREVIEW = 'PREVIEW'
-}

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -3,17 +3,14 @@ import { usePickerConfig } from '../components/context/PickerConfigContext';
 import {
   EmojiClickData,
   EmojiStyle,
+  SkinTonePickerLocation,
   SkinTones,
   SuggestionMode,
   Theme
 } from '../types/exposedTypes';
 
 import { CategoriesConfig } from './categoryConfig';
-import {
-  PickerDimensions,
-  PreviewConfig,
-  SkinTonePickerLocation
-} from './config';
+import { PickerDimensions, PreviewConfig } from './config';
 
 export function useSearchPlaceHolderConfig(): string {
   const { searchPlaceHolder } = usePickerConfig();

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -9,7 +9,11 @@ import {
 } from '../types/exposedTypes';
 
 import { CategoriesConfig } from './categoryConfig';
-import { PickerDimensions, PreviewConfig } from './config';
+import {
+  PickerDimensions,
+  PreviewConfig,
+  SkinTonePickerLocation
+} from './config';
 
 export function useSearchPlaceHolderConfig(): string {
   const { searchPlaceHolder } = usePickerConfig();
@@ -90,6 +94,11 @@ export function useEmojiVersionConfig(): string | null {
 export function useSearchDisabledConfig(): boolean {
   const { searchDisabled } = usePickerConfig();
   return searchDisabled;
+}
+
+export function useSkinTonePickerLocationConfig(): SkinTonePickerLocation {
+  const { skinTonePickerLocation } = usePickerConfig();
+  return skinTonePickerLocation;
 }
 
 export function useGetEmojiUrlConfig(): (

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -87,6 +87,11 @@ export function useEmojiVersionConfig(): string | null {
   return emojiVersion;
 }
 
+export function useSearchDisabledConfig(): boolean {
+  const { searchDisabled } = usePickerConfig();
+  return searchDisabled;
+}
+
 export function useGetEmojiUrlConfig(): (
   unified: string,
   style: EmojiStyle

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -38,6 +38,10 @@ import {
 } from './useFocus';
 import useIsSearchMode from './useIsSearchMode';
 import useSetVariationPicker from './useSetVariationPicker';
+import {
+  useIsSkinToneInPreview,
+  useIsSkinToneInSearch
+} from './useShouldShowSkinTonePicker';
 
 enum KeyboardEvents {
   ArrowDown = 'ArrowDown',
@@ -120,6 +124,7 @@ function useSearchInputKeyboardEvents() {
   const SearchInputRef = useSearchInputRef();
   const [, setSkinToneFanOpenState] = useSkinToneFanOpenState();
   const goDownFromSearchInput = useGoDownFromSearchInput();
+  const isSkinToneInSearch = useIsSkinToneInSearch();
 
   const onKeyDown = useMemo(
     () =>
@@ -128,6 +133,9 @@ function useSearchInputKeyboardEvents() {
 
         switch (key) {
           case KeyboardEvents.ArrowRight:
+            if (!isSkinToneInSearch) {
+              return;
+            }
             event.preventDefault();
             setSkinToneFanOpenState(true);
             focusSkinTonePicker();
@@ -171,41 +179,76 @@ function useSkinTonePickerKeyboardEvents() {
   const SearchInputRef = useSearchInputRef();
   const goDownFromSearchInput = useGoDownFromSearchInput();
   const [isOpen, setIsOpen] = useSkinToneFanOpenState();
+  const isSkinToneInPreview = useIsSkinToneInPreview();
+  const isSkinToneInSearch = useIsSkinToneInSearch();
   const onType = useOnType();
 
   const onKeyDown = useMemo(
     () =>
+      // eslint-disable-next-line complexity
       function onKeyDown(event: KeyboardEvent) {
         const { key } = event;
 
-        switch (key) {
-          case KeyboardEvents.ArrowLeft:
-            event.preventDefault();
-            if (!isOpen) {
-              return focusSearchInput();
-            }
-            focusNextSkinTone(focusSearchInput);
-            break;
-          case KeyboardEvents.ArrowRight:
-            event.preventDefault();
-            if (!isOpen) {
-              return focusSearchInput();
-            }
-            focusPrevSkinTone();
-            break;
-          case KeyboardEvents.ArrowDown:
-            event.preventDefault();
-            if (isOpen) {
-              setIsOpen(false);
-            }
-            goDownFromSearchInput();
-            break;
-          default:
-            onType(event);
-            break;
+        if (isSkinToneInSearch) {
+          switch (key) {
+            case KeyboardEvents.ArrowLeft:
+              event.preventDefault();
+              if (!isOpen) {
+                return focusSearchInput();
+              }
+              focusNextSkinTone(focusSearchInput);
+              break;
+            case KeyboardEvents.ArrowRight:
+              event.preventDefault();
+              if (!isOpen) {
+                return focusSearchInput();
+              }
+              focusPrevSkinTone();
+              break;
+            case KeyboardEvents.ArrowDown:
+              event.preventDefault();
+              if (isOpen) {
+                setIsOpen(false);
+              }
+              goDownFromSearchInput();
+              break;
+            default:
+              onType(event);
+              break;
+          }
+        }
+
+        if (isSkinToneInPreview) {
+          switch (key) {
+            case KeyboardEvents.ArrowUp:
+              event.preventDefault();
+              if (!isOpen) {
+                return focusSearchInput();
+              }
+              focusNextSkinTone(focusSearchInput);
+              break;
+            case KeyboardEvents.ArrowDown:
+              event.preventDefault();
+              if (!isOpen) {
+                return focusSearchInput();
+              }
+              focusPrevSkinTone();
+              break;
+            default:
+              onType(event);
+              break;
+          }
         }
       },
-    [isOpen, focusSearchInput, setIsOpen, goDownFromSearchInput, onType]
+    [
+      isOpen,
+      focusSearchInput,
+      setIsOpen,
+      goDownFromSearchInput,
+      onType,
+      isSkinToneInPreview,
+      isSkinToneInSearch
+    ]
   );
 
   useEffect(() => {

--- a/src/hooks/useShouldShowSkinTonePicker.ts
+++ b/src/hooks/useShouldShowSkinTonePicker.ts
@@ -1,0 +1,10 @@
+import { SkinTonePickerLocation } from '../config/config';
+import { useSkinTonePickerLocationConfig } from '../config/useConfig';
+
+export function useShouldShowSkinTonePicker() {
+  const skinTonePickerLocationConfig = useSkinTonePickerLocationConfig();
+
+  return function shouldShowSkinTonePicker(location: SkinTonePickerLocation) {
+    return skinTonePickerLocationConfig === location;
+  };
+}

--- a/src/hooks/useShouldShowSkinTonePicker.ts
+++ b/src/hooks/useShouldShowSkinTonePicker.ts
@@ -1,5 +1,5 @@
-import { SkinTonePickerLocation } from '../config/config';
 import { useSkinTonePickerLocationConfig } from '../config/useConfig';
+import { SkinTonePickerLocation } from '../types/exposedTypes';
 
 export function useShouldShowSkinTonePicker() {
   const skinTonePickerLocationConfig = useSkinTonePickerLocationConfig();
@@ -7,4 +7,16 @@ export function useShouldShowSkinTonePicker() {
   return function shouldShowSkinTonePicker(location: SkinTonePickerLocation) {
     return skinTonePickerLocationConfig === location;
   };
+}
+
+export function useIsSkinToneInSearch() {
+  const skinTonePickerLocationConfig = useSkinTonePickerLocationConfig();
+
+  return skinTonePickerLocationConfig === SkinTonePickerLocation.SEARCH;
+}
+
+export function useIsSkinToneInPreview() {
+  const skinTonePickerLocationConfig = useSkinTonePickerLocationConfig();
+
+  return skinTonePickerLocationConfig === SkinTonePickerLocation.PREVIEW;
 }

--- a/src/types/exposedTypes.ts
+++ b/src/types/exposedTypes.ts
@@ -9,7 +9,7 @@ export type EmojiClickData = {
 
 export enum SuggestionMode {
   RECENT = 'recent',
-  FREQUENT = 'frequent',
+  FREQUENT = 'frequent'
 }
 
 export enum EmojiStyle {
@@ -17,13 +17,13 @@ export enum EmojiStyle {
   APPLE = 'apple',
   TWITTER = 'twitter',
   GOOGLE = 'google',
-  FACEBOOK = 'facebook',
+  FACEBOOK = 'facebook'
 }
 
 export enum Theme {
   DARK = 'dark',
   LIGHT = 'light',
-  AUTO = 'auto',
+  AUTO = 'auto'
 }
 
 export enum SkinTones {
@@ -32,7 +32,7 @@ export enum SkinTones {
   MEDIUM_LIGHT = '1f3fc',
   MEDIUM = '1f3fd',
   MEDIUM_DARK = '1f3fe',
-  DARK = '1f3ff',
+  DARK = '1f3ff'
 }
 
 export enum Categories {
@@ -44,5 +44,10 @@ export enum Categories {
   ACTIVITIES = 'activities',
   OBJECTS = 'objects',
   SYMBOLS = 'symbols',
-  FLAGS = 'flags',
+  FLAGS = 'flags'
+}
+
+export enum SkinTonePickerLocation {
+  SEARCH = 'SEARCH',
+  PREVIEW = 'PREVIEW'
 }

--- a/stories/picker.stories.tsx
+++ b/stories/picker.stories.tsx
@@ -9,8 +9,11 @@ import EmojiPicker, {
   Theme
 } from '../src';
 import { Categories } from '../src/config/categoryConfig';
-import { SkinTonePickerLocation } from '../src/config/config';
-import { SuggestionMode } from '../src/types/exposedTypes';
+import { useSkinTonePickerLocationConfig } from '../src/config/useConfig';
+import {
+  SkinTonePickerLocation,
+  SuggestionMode
+} from '../src/types/exposedTypes';
 
 const meta: Meta = {
   title: 'Picker',
@@ -46,6 +49,10 @@ export const AutoTheme = (args: Props) => (
 
 export const SearchDisabled = (args: Props) => (
   <Template {...args} searchDisabled />
+);
+
+export const SearchDisabledDark = (args: Props) => (
+  <TemplateDark {...args} searchDisabled theme={Theme.DARK} />
 );
 
 export const SkinTonePickerInPreview = (args: Props) => (

--- a/stories/picker.stories.tsx
+++ b/stories/picker.stories.tsx
@@ -42,6 +42,10 @@ export const Dark = (args: Props) => (
 export const AutoTheme = (args: Props) => (
   <TemplateDark {...args} theme={Theme.AUTO} />
 );
+
+export const SearchDisabled = (args: Props) => (
+  <Template {...args} searchDisabled />
+);
 export const CustomSizeDimensionsNumbers = (args: Props) => (
   <TemplateDark
     {...args}

--- a/stories/picker.stories.tsx
+++ b/stories/picker.stories.tsx
@@ -9,6 +9,7 @@ import EmojiPicker, {
   Theme
 } from '../src';
 import { Categories } from '../src/config/categoryConfig';
+import { SkinTonePickerLocation } from '../src/config/config';
 import { SuggestionMode } from '../src/types/exposedTypes';
 
 const meta: Meta = {
@@ -45,6 +46,14 @@ export const AutoTheme = (args: Props) => (
 
 export const SearchDisabled = (args: Props) => (
   <Template {...args} searchDisabled />
+);
+
+export const SkinTonePickerInPreview = (args: Props) => (
+  <Template
+    {...args}
+    emojiStyle={EmojiStyle.NATIVE}
+    skinTonePickerLocation={SkinTonePickerLocation.PREVIEW}
+  />
 );
 export const CustomSizeDimensionsNumbers = (args: Props) => (
   <TemplateDark


### PR DESCRIPTION
Related to: #283


Adding the following props: 

- `searchDisabled`: `boolean` - Whether to disable the search input. Defaults to `false`. When disabled, the skin tone picker will be shown in the preview component.

- `skinTonesDisabled`: `boolean` - Whether to disable the skin tone selection. Defaults to `false`.

Published in `emoji-picker-react@4.4.0-rc.2`.