### PR TITLE
Persist skin tone via keyboard actions

### DIFF
--- a/src/components/Layout/Relative.tsx
+++ b/src/components/Layout/Relative.tsx
@@ -4,11 +4,14 @@ type Props = Readonly<{
   children: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
+  tabIndex?: number;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 }>;
 
-export default function Relative({ children, className, style }: Props) {
+export default function Relative({ children, className, style, tabIndex, onKeyDown }: Props) {
   return (
-    <div style={{ ...style, position: 'relative' }} className={className}>
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div style={{ ...style, position: 'relative' }} className={className} tabIndex={tabIndex} onKeyDown={onKeyDown}>
       {children}
     </div>
   );

--- a/src/components/context/PickerContext.tsx
+++ b/src/components/context/PickerContext.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useDefaultSkinToneConfig } from '../../config/useConfig';
 import { DataEmoji } from '../../dataUtils/DataTypes';
 import { alphaNumericEmojiIndex } from '../../dataUtils/alphaNumericEmojiIndex';
+import { getSkinTone, setSkinTone } from '../../dataUtils/skinTone';
 import { useDebouncedState } from '../../hooks/useDebouncedState';
 import { useDisallowedEmojis } from '../../hooks/useDisallowedEmojis';
 import { FilterDict } from '../../hooks/useFilter';
@@ -61,7 +62,7 @@ const PickerContext = React.createContext<{
   searchTerm: [string, (term: string) => Promise<string>];
   suggestedUpdateState: [number, (term: number) => void];
   activeCategoryState: ReactState<ActiveCategoryState>;
-  activeSkinTone: ReactState<SkinTones>;
+  activeSkinTone: [SkinTones, (skinTone: SkinTones) => void];
   emojisThatFailedToLoadState: ReactState<Set<string>>;
   isPastInitialLoad: boolean;
   emojiVariationPickerState: ReactState<DataEmoji | null>;
@@ -71,18 +72,18 @@ const PickerContext = React.createContext<{
   disallowMouseRef: React.MutableRefObject<boolean>;
   disallowedEmojisRef: React.MutableRefObject<Record<string, boolean>>;
 }>({
-  activeCategoryState: [null, () => {}],
-  activeSkinTone: [SkinTones.NEUTRAL, () => {}],
+  activeCategoryState: [null, () => { }],
+  activeSkinTone: [getSkinTone(), (skinTone) => setSkinTone(skinTone)],
   disallowClickRef: { current: false },
   disallowMouseRef: { current: false },
   disallowedEmojisRef: { current: {} },
-  emojiVariationPickerState: [null, () => {}],
-  emojisThatFailedToLoadState: [new Set(), () => {}],
+  emojiVariationPickerState: [null, () => { }],
+  emojisThatFailedToLoadState: [new Set(), () => { }],
   filterRef: { current: {} },
   isPastInitialLoad: true,
   searchTerm: ['', () => new Promise<string>(() => undefined)],
-  skinToneFanOpenState: [false, () => {}],
-  suggestedUpdateState: [Date.now(), () => {}]
+  skinToneFanOpenState: [false, () => { }],
+  suggestedUpdateState: [Date.now(), () => { }]
 });
 
 type Props = Readonly<{

--- a/src/components/header/Search.tsx
+++ b/src/components/header/Search.tsx
@@ -75,6 +75,7 @@ export function Search() {
       <div className="epr-icn-search" />
       <Button
         className={clsx('epr-btn-clear-search', 'epr-visible-on-search-only')}
+        aria-label={'Clear search'}
         onClick={clearSearch}
       >
         <div className="epr-icn-clear-search" />

--- a/src/components/header/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker.tsx
@@ -9,6 +9,7 @@ import skinToneVariations, {
 import { setSkinTone } from '../../dataUtils/skinTone';
 import { useCloseAllOpenToggles } from '../../hooks/useCloseAllOpenToggles';
 import { useFocusSearchInput } from '../../hooks/useFocus';
+import { KeyboardEvents } from '../../hooks/useKeyboardNavigation';
 import { SkinTones } from '../../types/exposedTypes';
 import Absolute from '../Layout/Absolute';
 import Relative from '../Layout/Relative';
@@ -66,8 +67,18 @@ export function SkinTonePicker({
           ? { flexBasis: expandedSize, height: expandedSize }
           : { flexBasis: expandedSize }
       }
+      tabIndex={0}
+      onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+        const { key } = event;
+        if (key === KeyboardEvents.Enter) {
+          if (!isOpen) {
+            setIsOpen(true)
+          }
+          closeAllOpenToggles();
+        }
+      }}
     >
-      <div className="epr-skin-tone-select" ref={SkinTonePickerRef}>
+      <div className="epr-skin-tone-select" ref={SkinTonePickerRef} >
         {skinToneVariations.map((skinToneVariation, i) => {
           const active = skinToneVariation === activeSkinTone;
           return (
@@ -90,11 +101,24 @@ export function SkinTonePicker({
                 }
                 closeAllOpenToggles();
               }}
+              // when tabbed onto the SkinTonePicker, allow Enter to open and close the fan of colors
+              onKeyDown={(event) => {
+                const { key } = event;
+                if (key === KeyboardEvents.Enter) {
+                  if (isOpen) {
+                    setActiveSkinTone(skinToneVariation);
+                    focusSearchInput();
+                  } else {
+                    setIsOpen(true);
+                  }
+                  closeAllOpenToggles();
+                }
+              }}
+              tabIndex={isOpen ? 0 : -1}
               key={skinToneVariation}
               className={clsx(`epr-tone-${skinToneVariation}`, 'epr-tone', {
                 [ClassNames.active]: active
               })}
-              tabIndex={isOpen ? 0 : -1}
               aria-pressed={active}
               aria-label={`Skin tone ${skinTonesNamed[skinToneVariation as SkinTones]
                 }`}

--- a/src/components/header/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker.tsx
@@ -6,6 +6,7 @@ import { useSkinTonesDisabledConfig } from '../../config/useConfig';
 import skinToneVariations, {
   skinTonesNamed
 } from '../../data/skinToneVariations';
+import { setSkinTone } from '../../dataUtils/skinTone';
 import { useCloseAllOpenToggles } from '../../hooks/useCloseAllOpenToggles';
 import { useFocusSearchInput } from '../../hooks/useFocus';
 import { SkinTones } from '../../types/exposedTypes';
@@ -82,6 +83,7 @@ export function SkinTonePicker({
               onClick={() => {
                 if (isOpen) {
                   setActiveSkinTone(skinToneVariation);
+                  setSkinTone(skinToneVariation)
                   focusSearchInput();
                 } else {
                   setIsOpen(true);
@@ -94,9 +96,8 @@ export function SkinTonePicker({
               })}
               tabIndex={isOpen ? 0 : -1}
               aria-pressed={active}
-              aria-label={`Skin tone ${
-                skinTonesNamed[skinToneVariation as SkinTones]
-              }`}
+              aria-label={`Skin tone ${skinTonesNamed[skinToneVariation as SkinTones]
+                }`}
             ></Button>
           );
         })}

--- a/src/components/header/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker.tsx
@@ -107,6 +107,7 @@ export function SkinTonePicker({
                 if (key === KeyboardEvents.Enter) {
                   if (isOpen) {
                     setActiveSkinTone(skinToneVariation);
+                    setSkinTone(skinToneVariation)
                     focusSearchInput();
                   } else {
                     setIsOpen(true);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,5 +1,6 @@
 import { GetEmojiUrl } from '../components/emoji/Emoji';
 import { emojiUrlByUnified } from '../dataUtils/emojiSelectors';
+import { getSkinTone } from '../dataUtils/skinTone';
 import {
   EmojiClickData,
   EmojiStyle,
@@ -30,6 +31,8 @@ export function mergeConfig(
     suggestionMode: config.suggestedEmojisMode
   });
 
+  const activeSkinTone = getSkinTone()
+
   const skinTonePickerLocation = config.searchDisabled
     ? SkinTonePickerLocation.PREVIEW
     : config.skinTonePickerLocation;
@@ -37,6 +40,7 @@ export function mergeConfig(
   return {
     ...config,
     categories,
+    defaultSkinTone: activeSkinTone,
     previewConfig,
     skinTonePickerLocation
   };

--- a/src/dataUtils/skinTone.ts
+++ b/src/dataUtils/skinTone.ts
@@ -1,0 +1,25 @@
+import { SkinTones } from '../types/exposedTypes';
+
+const SKINTONE_LS_KEY = 'epr_skin_tone';
+
+
+export function getSkinTone(): SkinTones {
+  try {
+    if (!window?.localStorage) {
+      return SkinTones.NEUTRAL;
+    }
+
+    return JSON.parse(window?.localStorage.getItem(SKINTONE_LS_KEY) ?? SkinTones.NEUTRAL)
+  } catch {
+    return SkinTones.NEUTRAL;
+  }
+}
+
+export function setSkinTone(skinTone: SkinTones) {
+  try {
+    window?.localStorage.setItem(SKINTONE_LS_KEY, JSON.stringify(skinTone));
+    // Prevents the change from being seen immediately.
+  } catch {
+    // ignore
+  }
+}

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -43,7 +43,7 @@ import {
   useIsSkinToneInSearch
 } from './useShouldShowSkinTonePicker';
 
-enum KeyboardEvents {
+export enum KeyboardEvents {
   ArrowDown = 'ArrowDown',
   ArrowUp = 'ArrowUp',
   ArrowLeft = 'ArrowLeft',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ export {
   SkinTonePickerLocation
 } from './types/exposedTypes';
 
-export interface Props extends PickerConfig {}
+export interface Props extends PickerConfig { }
 
 export default function EmojiPicker(props: Props) {
   return (


### PR DESCRIPTION
Missed this. When tabbed onto a skin tone, on Enter, the skin tone should be persisted to localStorage just as it is on click.