### PR TITLE
Skin Tone Accessibility Updates

### DIFF
--- a/src/components/Layout/Relative.tsx
+++ b/src/components/Layout/Relative.tsx
@@ -4,10 +4,27 @@ type Props = Readonly<{
   children: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
+  button?: boolean;
+  tabIndex?: number;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
 }>;
 
-export default function Relative({ children, className, style }: Props) {
-  return (
+export default function Relative({
+  children,
+  className,
+  style,
+  button,
+  tabIndex,
+  onKeyDown
+}: Props) {
+  return button ? (
+    <button
+      style={{ ...style, position: 'relative' }}
+      className={className}
+      tabIndex={tabIndex}
+      onKeyDown={onKeyDown}
+    >{children}</button>
+  ) : (
     <div style={{ ...style, position: 'relative' }} className={className}>
       {children}
     </div>

--- a/src/components/Layout/Relative.tsx
+++ b/src/components/Layout/Relative.tsx
@@ -6,11 +6,7 @@ type Props = Readonly<{
   style?: React.CSSProperties;
 }>;
 
-export default function Relative({
-  children,
-  className,
-  style
-}: Props) {
+export default function Relative({ children, className, style }: Props) {
   return (
     <div style={{ ...style, position: 'relative' }} className={className}>
       {children}

--- a/src/components/Layout/Relative.tsx
+++ b/src/components/Layout/Relative.tsx
@@ -4,27 +4,14 @@ type Props = Readonly<{
   children: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
-  button?: boolean;
-  tabIndex?: number;
-  onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
 }>;
 
 export default function Relative({
   children,
   className,
-  style,
-  button,
-  tabIndex,
-  onKeyDown
+  style
 }: Props) {
-  return button ? (
-    <button
-      style={{ ...style, position: 'relative' }}
-      className={className}
-      tabIndex={tabIndex}
-      onKeyDown={onKeyDown}
-    >{children}</button>
-  ) : (
+  return (
     <div style={{ ...style, position: 'relative' }} className={className}>
       {children}
     </div>

--- a/src/components/context/PickerContext.tsx
+++ b/src/components/context/PickerContext.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useDefaultSkinToneConfig } from '../../config/useConfig';
 import { DataEmoji } from '../../dataUtils/DataTypes';
 import { alphaNumericEmojiIndex } from '../../dataUtils/alphaNumericEmojiIndex';
+import { getSkinTone, setSkinTone } from '../../dataUtils/skinTone';
 import { useDebouncedState } from '../../hooks/useDebouncedState';
 import { useDisallowedEmojis } from '../../hooks/useDisallowedEmojis';
 import { FilterDict } from '../../hooks/useFilter';
@@ -61,7 +62,7 @@ const PickerContext = React.createContext<{
   searchTerm: [string, (term: string) => Promise<string>];
   suggestedUpdateState: [number, (term: number) => void];
   activeCategoryState: ReactState<ActiveCategoryState>;
-  activeSkinTone: ReactState<SkinTones>;
+  activeSkinTone: [SkinTones, (skinTone: SkinTones) => void];
   emojisThatFailedToLoadState: ReactState<Set<string>>;
   isPastInitialLoad: boolean;
   emojiVariationPickerState: ReactState<DataEmoji | null>;
@@ -71,18 +72,18 @@ const PickerContext = React.createContext<{
   disallowMouseRef: React.MutableRefObject<boolean>;
   disallowedEmojisRef: React.MutableRefObject<Record<string, boolean>>;
 }>({
-  activeCategoryState: [null, () => {}],
-  activeSkinTone: [SkinTones.NEUTRAL, () => {}],
+  activeCategoryState: [null, () => { }],
+  activeSkinTone: [getSkinTone(), (skinTone) => setSkinTone(skinTone)],
   disallowClickRef: { current: false },
   disallowMouseRef: { current: false },
   disallowedEmojisRef: { current: {} },
-  emojiVariationPickerState: [null, () => {}],
-  emojisThatFailedToLoadState: [new Set(), () => {}],
+  emojiVariationPickerState: [null, () => { }],
+  emojisThatFailedToLoadState: [new Set(), () => { }],
   filterRef: { current: {} },
   isPastInitialLoad: true,
   searchTerm: ['', () => new Promise<string>(() => undefined)],
-  skinToneFanOpenState: [false, () => {}],
-  suggestedUpdateState: [Date.now(), () => {}]
+  skinToneFanOpenState: [false, () => { }],
+  suggestedUpdateState: [Date.now(), () => { }]
 });
 
 type Props = Readonly<{

--- a/src/components/header/Search.tsx
+++ b/src/components/header/Search.tsx
@@ -76,6 +76,7 @@ export function Search() {
       <Button
         className={clsx('epr-btn-clear-search', 'epr-visible-on-search-only')}
         onClick={clearSearch}
+        aria-label={'Clear search'}
       >
         <div className="epr-icn-clear-search" />
       </Button>

--- a/src/components/header/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker.tsx
@@ -94,17 +94,6 @@ export function SkinTonePicker({
           ? { flexBasis: expandedSize, height: expandedSize, ...buttonStyle }
           : { flexBasis: expandedSize, ...buttonStyle }
       }
-      button={true}
-      tabIndex={0}
-      onKeyDown={(event: React.KeyboardEvent<HTMLButtonElement>) => {
-        const { key } = event;
-        if (key === KeyboardEvents.Enter) {
-          if (!isOpen) {
-            setIsOpen(true)
-          }
-          closeAllOpenToggles();
-        }
-      }}
     >
       <div className="epr-skin-tone-select" ref={SkinTonePickerRef}>
         {skinToneVariations.map((skinToneVariation, i) => {

--- a/src/components/header/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker.tsx
@@ -4,8 +4,9 @@ import * as React from 'react';
 import { ClassNames } from '../../DomUtils/classNames';
 import { useSkinTonesDisabledConfig } from '../../config/useConfig';
 import skinToneVariations, {
-  skinTonesNamed
+  skinTonesNamed,
 } from '../../data/skinToneVariations';
+import { setSkinTone } from '../../dataUtils/skinTone';
 import { useCloseAllOpenToggles } from '../../hooks/useCloseAllOpenToggles';
 import { useFocusSearchInput } from '../../hooks/useFocus';
 import { SkinTones } from '../../types/exposedTypes';
@@ -82,6 +83,7 @@ export function SkinTonePicker({
               onClick={() => {
                 if (isOpen) {
                   setActiveSkinTone(skinToneVariation);
+                  setSkinTone(skinToneVariation)
                   focusSearchInput();
                 } else {
                   setIsOpen(true);

--- a/src/components/header/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker.tsx
@@ -59,29 +59,6 @@ export function SkinTonePicker({
 
   const vertical = direction === SkinTonePickerDirection.VERTICAL;
 
-  const getHorizontalTranslation = ({
-    ix,
-    fanOutDirection,
-    isOpen,
-  }: {
-    ix: number;
-    fanOutDirection: SkinTonePickerFanOutDirection;
-    isOpen: boolean;
-  }): string => {
-    // By fanning out to the left, the focus remains on the last (right-most) tone in the array,
-    // so tabbing takes a user out of the SkinTonePicker. In order to tab through the tones, a user
-    // must first tab backwards.
-    //
-    // Fanning out to the right keeps the focus on the first (left-most) tone in the array so a user
-    // can tab from left to right.
-    if (fanOutDirection === SkinTonePickerFanOutDirection.LEFT) {
-      return `translateX(-${ix * (isOpen ? ITEM_SIZE : 0)}px)`;
-    }
-    return `translateX(${ix * (isOpen ? ITEM_SIZE : 0) -
-      (isOpen ? (skinToneVariations.length - 1) * ITEM_SIZE : 0)
-      }px)`;
-  };
-
   const buttonStyle = { backgroundColor: "transparent", border: "none" }
 
   return (
@@ -150,6 +127,29 @@ export function SkinTonePicker({
       </div>
     </Relative>
   );
+
+  function getHorizontalTranslation({
+    ix,
+    fanOutDirection,
+    isOpen,
+  }: {
+    ix: number;
+    fanOutDirection: SkinTonePickerFanOutDirection;
+    isOpen: boolean;
+  }): string {
+    // By fanning out to the left, the focus remains on the last (right-most) tone in the array,
+    // so tabbing takes a user out of the SkinTonePicker. In order to tab through the tones, a user
+    // must first tab backwards.
+    //
+    // Fanning out to the right keeps the focus on the first (left-most) tone in the array so a user
+    // can tab from left to right.
+    if (fanOutDirection === SkinTonePickerFanOutDirection.LEFT) {
+      return `translateX(-${ix * (isOpen ? ITEM_SIZE : 0)}px)`;
+    }
+    return `translateX(${ix * (isOpen ? ITEM_SIZE : 0) -
+      (isOpen ? (skinToneVariations.length - 1) * ITEM_SIZE : 0)
+      }px)`;
+  }
 }
 
 export enum SkinTonePickerDirection {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,5 +1,6 @@
 import { GetEmojiUrl } from '../components/emoji/Emoji';
 import { emojiUrlByUnified } from '../dataUtils/emojiSelectors';
+import { getSkinTone } from '../dataUtils/skinTone';
 import {
   EmojiClickData,
   EmojiStyle,
@@ -30,6 +31,8 @@ export function mergeConfig(
     suggestionMode: config.suggestedEmojisMode
   });
 
+  const activeSkinTone = getSkinTone()
+
   const skinTonePickerLocation = config.searchDisabled
     ? SkinTonePickerLocation.PREVIEW
     : config.skinTonePickerLocation;
@@ -37,6 +40,7 @@ export function mergeConfig(
   return {
     ...config,
     categories,
+    defaultSkinTone: activeSkinTone,
     previewConfig,
     skinTonePickerLocation
   };

--- a/src/dataUtils/skinTone.ts
+++ b/src/dataUtils/skinTone.ts
@@ -18,7 +18,6 @@ export function getSkinTone(): SkinTones {
 export function setSkinTone(skinTone: SkinTones) {
   try {
     window?.localStorage.setItem(SKINTONE_LS_KEY, JSON.stringify(skinTone));
-    // Prevents the change from being seen immediately.
   } catch {
     // ignore
   }

--- a/src/dataUtils/skinTone.ts
+++ b/src/dataUtils/skinTone.ts
@@ -1,0 +1,25 @@
+import { SkinTones } from '../types/exposedTypes';
+
+const SKINTONE_LS_KEY = 'epr_skin_tone';
+
+
+export function getSkinTone(): SkinTones {
+  try {
+    if (!window?.localStorage) {
+      return SkinTones.NEUTRAL;
+    }
+
+    return JSON.parse(window?.localStorage.getItem(SKINTONE_LS_KEY) ?? SkinTones.NEUTRAL)
+  } catch {
+    return SkinTones.NEUTRAL;
+  }
+}
+
+export function setSkinTone(skinTone: SkinTones) {
+  try {
+    window?.localStorage.setItem(SKINTONE_LS_KEY, JSON.stringify(skinTone));
+    // Prevents the change from being seen immediately.
+  } catch {
+    // ignore
+  }
+}

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -50,7 +50,8 @@ export enum KeyboardEvents {
   ArrowRight = 'ArrowRight',
   Escape = 'Escape',
   Enter = 'Enter',
-  Space = ' '
+  Space = ' ',
+  Tab = "Tab"
 }
 
 export function useKeyboardNavigation() {
@@ -132,6 +133,7 @@ function useSearchInputKeyboardEvents() {
         const { key } = event;
 
         switch (key) {
+          case KeyboardEvents.Tab:
           case KeyboardEvents.ArrowRight:
             if (!isSkinToneInSearch) {
               return;

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -43,7 +43,7 @@ import {
   useIsSkinToneInSearch
 } from './useShouldShowSkinTonePicker';
 
-enum KeyboardEvents {
+export enum KeyboardEvents {
   ArrowDown = 'ArrowDown',
   ArrowUp = 'ArrowUp',
   ArrowLeft = 'ArrowLeft',

--- a/src/hooks/useKeyboardNavigation.ts
+++ b/src/hooks/useKeyboardNavigation.ts
@@ -12,7 +12,7 @@ import {
   focusNextVisibleEmoji,
   focusPrevVisibleEmoji,
   focusVisibleEmojiOneRowDown,
-  focusVisibleEmojiOneRowUp
+  focusVisibleEmojiOneRowUp,
 } from '../DomUtils/keyboardNavigation';
 import { useScrollTo } from '../DomUtils/scrollTo';
 import { buttonFromTarget } from '../DomUtils/selectors';


### PR DESCRIPTION
In this PR, I added a few changes to assist with keyboard accessibility and general usage of the Skin Tone Picker.

1 - Unrelated: Adds an aria-label to the Clear Search "x" button
2 - Adds functionality to persist selected skin tone in `localStorage`
3 - Allows a user to tab into the Skin Tone Picker
4 - Adds a prop, `fanOutDirection` to the `<SkinTonePicker />` component to maintain the default fan-out behavior - which keeps the selected tone in-place and fans all remaining colors to to the left - and adds an option to specify the opposite, where colors will fan out to the right of the selected tone. The goal here was to aid with tab-ability and not interrupt the left --> right tab flow. 

https://user-images.githubusercontent.com/22733487/211915727-868da0fc-094d-4df4-91bc-7043f5e14753.mov

