### PR TITLE
Hide emojis by unicode

### DIFF
--- a/src/config/categoryConfig.ts
+++ b/src/config/categoryConfig.ts
@@ -3,7 +3,7 @@ import { Categories, SuggestionMode } from '../types/exposedTypes';
 export { Categories };
 
 const categoriesOrdered: Categories[] = [
-  Categories.SUGGESTED,
+  // Categories.SUGGESTED, TODO dont show on suggested
   Categories.SMILEYS_PEOPLE,
   Categories.ANIMALS_NATURE,
   Categories.FOOD_DRINK,

--- a/src/config/categoryConfig.ts
+++ b/src/config/categoryConfig.ts
@@ -3,7 +3,7 @@ import { Categories, SuggestionMode } from '../types/exposedTypes';
 export { Categories };
 
 const categoriesOrdered: Categories[] = [
-  // Categories.SUGGESTED, TODO dont show on suggested
+  Categories.SUGGESTED,
   Categories.SMILEYS_PEOPLE,
   Categories.ANIMALS_NATURE,
   Categories.FOOD_DRINK,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -70,7 +70,7 @@ export function basePickerConfig(): PickerConfigInternal {
     suggestedEmojisMode: SuggestionMode.FREQUENT,
     theme: Theme.LIGHT,
     width: 350,
-    unicodeToHide: [],
+    unicodeToHide: new Set<string>(),
   };
 }
 
@@ -92,7 +92,7 @@ export type PickerConfigInternal = {
   getEmojiUrl: GetEmojiUrl;
   searchDisabled: boolean;
   skinTonePickerLocation: SkinTonePickerLocation;
-  unicodeToHide: string[];
+  unicodeToHide: Set<string>;
 };
 
 export type PreviewConfig = {
@@ -109,7 +109,7 @@ const basePreviewConfig: PreviewConfig = {
 
 type ConfigExternal = {
   previewConfig: Partial<PreviewConfig>;
-} & Omit<PickerConfigInternal, 'previewConfig'>;
+} & Omit<PickerConfigInternal, 'previewConfig' | 'unicodeToHide'>;
 
 export type PickerConfig = Partial<ConfigExternal>;
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -70,7 +70,7 @@ export function basePickerConfig(): PickerConfigInternal {
     suggestedEmojisMode: SuggestionMode.FREQUENT,
     theme: Theme.LIGHT,
     width: 350,
-    hideUnicodeCharacters: [],
+    unicodeToHide: [],
   };
 }
 
@@ -92,7 +92,7 @@ export type PickerConfigInternal = {
   getEmojiUrl: GetEmojiUrl;
   searchDisabled: boolean;
   skinTonePickerLocation: SkinTonePickerLocation;
-  hideUnicodeCharacters: string[] // TODO Can we have this as a const list ?
+  unicodeToHide: string[];
 };
 
 export type PreviewConfig = {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -69,7 +69,8 @@ export function basePickerConfig(): PickerConfigInternal {
     skinTonesDisabled: false,
     suggestedEmojisMode: SuggestionMode.FREQUENT,
     theme: Theme.LIGHT,
-    width: 350
+    width: 350,
+    hideUnicodeCharacters: [],
   };
 }
 
@@ -91,6 +92,7 @@ export type PickerConfigInternal = {
   getEmojiUrl: GetEmojiUrl;
   searchDisabled: boolean;
   skinTonePickerLocation: SkinTonePickerLocation;
+  hideUnicodeCharacters: string[] // TODO Can we have this as a const list ?
 };
 
 export type PreviewConfig = {

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -98,7 +98,7 @@ export function useSkinTonePickerLocationConfig(): SkinTonePickerLocation {
   return skinTonePickerLocation;
 }
 
-export function useUnicodeToHide(): string[] {
+export function useUnicodeToHide() {
   const { unicodeToHide } = usePickerConfig();
   return unicodeToHide;
 }

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -98,9 +98,9 @@ export function useSkinTonePickerLocationConfig(): SkinTonePickerLocation {
   return skinTonePickerLocation;
 }
 
-export function useHideUnicodeCharacters(): string[] {
-  const { hideUnicodeCharacters } = usePickerConfig();
-  return hideUnicodeCharacters;
+export function useUnicodeToHide(): string[] {
+  const { unicodeToHide } = usePickerConfig();
+  return unicodeToHide;
 }
 
 export function useGetEmojiUrlConfig(): (

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -98,6 +98,11 @@ export function useSkinTonePickerLocationConfig(): SkinTonePickerLocation {
   return skinTonePickerLocation;
 }
 
+export function useHideUnicodeCharacters(): string[] {
+  const { hideUnicodeCharacters } = usePickerConfig();
+  return hideUnicodeCharacters;
+}
+
 export function useGetEmojiUrlConfig(): (
   unified: string,
   style: EmojiStyle

--- a/src/hooks/useDisallowedEmojis.ts
+++ b/src/hooks/useDisallowedEmojis.ts
@@ -48,4 +48,4 @@ function addedInNewerVersion(
 ): boolean {
   return addedIn(emoji) > supportedLevel;
 }
- 
+

--- a/src/hooks/useDisallowedEmojis.ts
+++ b/src/hooks/useDisallowedEmojis.ts
@@ -1,6 +1,6 @@
 import { useRef, useMemo } from 'react';
 
-import { useEmojiVersionConfig } from '../config/useConfig';
+import { useEmojiVersionConfig, useHideUnicodeCharacters } from '../config/useConfig';
 import { DataEmoji } from '../dataUtils/DataTypes';
 import {
   addedIn,
@@ -36,9 +36,15 @@ export function useIsEmojiDisallowed() {
   return function isEmojiDisallowed(emoji: DataEmoji) {
     const unified = unifiedWithoutSkinTone(emojiUnified(emoji));
 
-    return Boolean(disallowedEmojis[unified]);
+    return Boolean(disallowedEmojis[unified] || hideEmojiJustForFun(unified));
   };
 }
+
+  // TODO this is just a POC, we need to hide emoji's base on different properties
+  function hideEmojiJustForFun(emojiUnified: string) {
+    const hideUnicodeCharacters = useHideUnicodeCharacters();
+    return hideUnicodeCharacters.includes(emojiUnified);
+  }
 
 function addedInNewerVersion(
   emoji: DataEmoji,

--- a/src/hooks/useDisallowedEmojis.ts
+++ b/src/hooks/useDisallowedEmojis.ts
@@ -48,3 +48,4 @@ function addedInNewerVersion(
 ): boolean {
   return addedIn(emoji) > supportedLevel;
 }
+ 

--- a/src/hooks/useDisallowedEmojis.ts
+++ b/src/hooks/useDisallowedEmojis.ts
@@ -1,6 +1,6 @@
 import { useRef, useMemo } from 'react';
 
-import { useEmojiVersionConfig, useHideUnicodeCharacters } from '../config/useConfig';
+import { useEmojiVersionConfig } from '../config/useConfig';
 import { DataEmoji } from '../dataUtils/DataTypes';
 import {
   addedIn,
@@ -8,6 +8,7 @@ import {
   emojiUnified,
   unifiedWithoutSkinTone
 } from '../dataUtils/emojiSelectors';
+import { useIsUnicodeHidden } from './useHideEmojisByUniocode';
 
 export function useDisallowedEmojis() {
   const DisallowedEmojisRef = useRef<Record<string, boolean>>({});
@@ -32,19 +33,14 @@ export function useDisallowedEmojis() {
 
 export function useIsEmojiDisallowed() {
   const disallowedEmojis = useDisallowedEmojis();
+  const isUnicodeHidden = useIsUnicodeHidden();
 
   return function isEmojiDisallowed(emoji: DataEmoji) {
     const unified = unifiedWithoutSkinTone(emojiUnified(emoji));
 
-    return Boolean(disallowedEmojis[unified] || hideEmojiJustForFun(unified));
+    return Boolean(disallowedEmojis[unified] || isUnicodeHidden(unified));
   };
 }
-
-  // TODO this is just a POC, we need to hide emoji's base on different properties
-  function hideEmojiJustForFun(emojiUnified: string) {
-    const hideUnicodeCharacters = useHideUnicodeCharacters();
-    return hideUnicodeCharacters.includes(emojiUnified);
-  }
 
 function addedInNewerVersion(
   emoji: DataEmoji,

--- a/src/hooks/useHideEmojisByUniocode.ts
+++ b/src/hooks/useHideEmojisByUniocode.ts
@@ -1,0 +1,6 @@
+import { useHideUnicodeCharacters } from "../config/useConfig";
+
+export function useIsUnicodeHidden() {
+    const hideUnicodeCharacters = useHideUnicodeCharacters();
+    return (emojiUnified: string) => hideUnicodeCharacters.includes(emojiUnified);
+  }

--- a/src/hooks/useHideEmojisByUniocode.ts
+++ b/src/hooks/useHideEmojisByUniocode.ts
@@ -2,5 +2,5 @@ import { useUnicodeToHide } from "../config/useConfig";
 
 export function useIsUnicodeHidden() {
     const unicodeToHide = useUnicodeToHide();
-    return (emojiUnified: string) => unicodeToHide.includes(emojiUnified);
+    return (emojiUnified: string) => unicodeToHide.has(emojiUnified);
   }

--- a/src/hooks/useHideEmojisByUniocode.ts
+++ b/src/hooks/useHideEmojisByUniocode.ts
@@ -1,6 +1,6 @@
-import { useHideUnicodeCharacters } from "../config/useConfig";
+import { useUnicodeToHide } from "../config/useConfig";
 
 export function useIsUnicodeHidden() {
-    const hideUnicodeCharacters = useHideUnicodeCharacters();
-    return (emojiUnified: string) => hideUnicodeCharacters.includes(emojiUnified);
+    const unicodeToHide = useUnicodeToHide();
+    return (emojiUnified: string) => unicodeToHide.includes(emojiUnified);
   }

--- a/stories/picker.stories.tsx
+++ b/stories/picker.stories.tsx
@@ -181,7 +181,7 @@ export const CustomUnifiedEmojiImage = () => {
 }
 
 export const HideEmojisByUnicode = (args: Props) => (
-  <Template unicodeToHide={[ '1f4a3' /*💣*/]} {...args} emojiStyle={EmojiStyle.NATIVE}  />
+  <Template {...args} emojiStyle={EmojiStyle.NATIVE}  />
 );
 
 function TemplateDark(args) {

--- a/stories/picker.stories.tsx
+++ b/stories/picker.stories.tsx
@@ -180,9 +180,8 @@ export const CustomUnifiedEmojiImage = () => {
   </>
 }
 
-// TODO what should we allow to hide ?
 export const HideEmojisByUnicode = (args: Props) => (
-  <Template hideUnicodeCharacters={[ '1f4a3' /*💣*/ ,'1f595' /*🖕*/ ]} {...args} emojiStyle={EmojiStyle.NATIVE}  />
+  <Template unicodeToHide={[ '1f4a3' /*💣*/]} {...args} emojiStyle={EmojiStyle.NATIVE}  />
 );
 
 function TemplateDark(args) {

--- a/stories/picker.stories.tsx
+++ b/stories/picker.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from '@storybook/react';
-import React, { useState, useSyncExternalStore } from 'react';
+import { Meta } from '@storybook/react';
+import React, { useState } from 'react';
 
 import EmojiPicker, {
   Emoji,
@@ -9,7 +9,6 @@ import EmojiPicker, {
   Theme
 } from '../src';
 import { Categories } from '../src/config/categoryConfig';
-import { useSkinTonePickerLocationConfig } from '../src/config/useConfig';
 import {
   SkinTonePickerLocation,
   SuggestionMode
@@ -31,10 +30,6 @@ const meta: Meta = {
 };
 
 export default meta;
-
-function onClick(...args) {
-  console.log(...args);
-}
 
 export const Native = (args: Props) => (
   <Template {...args} emojiStyle={EmojiStyle.NATIVE} />
@@ -184,6 +179,11 @@ export const CustomUnifiedEmojiImage = () => {
     <input onChange={(e) => setUnified(e.target.value)} value={unified} />
   </>
 }
+
+// TODO what should we allow to hide ?
+export const HideEmojisByUnicode = (args: Props) => (
+  <Template hideUnicodeCharacters={[ '1f4a3' /*💣*/ ,'1f595' /*🖕*/ ]} {...args} emojiStyle={EmojiStyle.NATIVE}  />
+);
 
 function TemplateDark(args) {
   const [shown, setShown] = useState(true);


### PR DESCRIPTION
Let's start with hiding unicode, for example `unicodeToHide={[ '1f4a3'] }`.
https://github.com/ealush/emoji-picker-react/assets/45143653/88a529a6-15e0-4a68-8fa0-2ed9d9afdfe5

