### PR TITLE
Added `searchPlaceholder` prop to config, as an alternative to `searchPlaceHolder`

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -17,6 +17,8 @@ import {
 
 const KNOWN_FAILING_EMOJIS = ['2640-fe0f', '2642-fe0f', '2695-fe0f'];
 
+export const DEFAULT_SEARCH_PLACEHOLDER = 'Search';
+
 export function mergeConfig(
   userConfig: PickerConfig = {}
 ): PickerConfigInternal {
@@ -66,7 +68,8 @@ export function basePickerConfig(): PickerConfigInternal {
       ...basePreviewConfig
     },
     searchDisabled: false,
-    searchPlaceHolder: 'Search',
+    searchPlaceHolder: DEFAULT_SEARCH_PLACEHOLDER,
+    searchPlaceholder: DEFAULT_SEARCH_PLACEHOLDER,
     skinTonePickerLocation: SkinTonePickerLocation.SEARCH,
     skinTonesDisabled: false,
     suggestedEmojisMode: SuggestionMode.FREQUENT,
@@ -79,6 +82,7 @@ export function basePickerConfig(): PickerConfigInternal {
 export type PickerConfigInternal = {
   emojiVersion: string | null;
   searchPlaceHolder: string;
+  searchPlaceholder: string;
   defaultSkinTone: SkinTones;
   skinTonesDisabled: boolean;
   autoFocusSearch: boolean;

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -10,11 +10,20 @@ import {
 } from '../types/exposedTypes';
 
 import { CategoriesConfig } from './categoryConfig';
-import { PickerDimensions, PreviewConfig } from './config';
+import {
+  DEFAULT_SEARCH_PLACEHOLDER,
+  PickerDimensions,
+  PreviewConfig,
+} from './config';
 
 export function useSearchPlaceHolderConfig(): string {
-  const { searchPlaceHolder } = usePickerConfig();
-  return searchPlaceHolder;
+  const { searchPlaceHolder, searchPlaceholder } = usePickerConfig();
+  return searchPlaceHolder !== DEFAULT_SEARCH_PLACEHOLDER ||
+    searchPlaceholder !== DEFAULT_SEARCH_PLACEHOLDER
+    ? searchPlaceHolder !== DEFAULT_SEARCH_PLACEHOLDER
+      ? searchPlaceHolder
+      : searchPlaceholder
+    : DEFAULT_SEARCH_PLACEHOLDER;
 }
 
 export function useDefaultSkinToneConfig(): SkinTones {

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -18,12 +18,11 @@ import {
 
 export function useSearchPlaceHolderConfig(): string {
   const { searchPlaceHolder, searchPlaceholder } = usePickerConfig();
-  return searchPlaceHolder !== DEFAULT_SEARCH_PLACEHOLDER ||
-    searchPlaceholder !== DEFAULT_SEARCH_PLACEHOLDER
-    ? searchPlaceHolder !== DEFAULT_SEARCH_PLACEHOLDER
-      ? searchPlaceHolder
-      : searchPlaceholder
-    : DEFAULT_SEARCH_PLACEHOLDER;
+  return (
+    [searchPlaceHolder, searchPlaceholder].find(
+      (p) => p !== DEFAULT_SEARCH_PLACEHOLDER
+    ) ?? DEFAULT_SEARCH_PLACEHOLDER
+  );
 }
 
 export function useDefaultSkinToneConfig(): SkinTones {


### PR DESCRIPTION
- Fixes #355 
- Added `searchPlaceholder` prop to `config.ts`.
- Added `DEFAULT_SEARCH_PLACEHOLDER` to `config.ts` - defines the default search placeholder string (defaulted to `Search`).
- Maps old `searchPlaceHolder` and new `searchPlaceholder` to the same prop when using `useSearchPlaceHolderConfig()`.
- ✅ Successfully passed testing on Storybook:
  - ✅ With custom `searchPlaceHolder`.
  - ✅ With custom `searchPlaceholder`.
  - ✅ Without custom `searchPlaceHolder` or `searchPlaceholder`.