### PR TITLE
Add alternative union string types

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "tiny-invariant": "^1.2.0",
     "tsdx": "^0.14.1",
     "tslib": "^2.4.0",
-    "typescript": "^4.7.4"
+    "typescript": "5.7.3"
   },
   "dependencies": {
     "flairup": "1.0.0"

--- a/src/Stylesheet/stylesheet.tsx
+++ b/src/Stylesheet/stylesheet.tsx
@@ -77,7 +77,7 @@ export const commonInteractionStyles = stylesheet.create({
   }
 });
 
-export function darkMode(key: string, value: Styles) {
+export function darkMode(key: string, value: Styles): Record<string, Record<string, Styles>> {
   return {
     '.epr-dark-theme': {
       [key]: value

--- a/src/components/body/EmojiCategory.tsx
+++ b/src/components/body/EmojiCategory.tsx
@@ -7,11 +7,7 @@ import {
   commonStyles,
   stylesheet
 } from '../../Stylesheet/stylesheet';
-import {
-  CategoryConfig,
-  categoryFromCategoryConfig,
-  categoryNameFromCategoryConfig
-} from '../../config/categoryConfig';
+import { CategoryConfig } from '../../config/categoryConfig';
 
 type Props = Readonly<{
   categoryConfig: CategoryConfig;
@@ -26,9 +22,7 @@ export function EmojiCategory({
   hidden,
   hiddenOnSearch
 }: Props) {
-  const category = categoryFromCategoryConfig(categoryConfig);
-  const categoryName = categoryNameFromCategoryConfig(categoryConfig);
-
+  const { category, name } = categoryConfig;
   return (
     <li
       className={cx(
@@ -37,9 +31,9 @@ export function EmojiCategory({
         hiddenOnSearch && commonInteractionStyles.hiddenOnSearch
       )}
       data-name={category}
-      aria-label={categoryName}
+      aria-label={name}
     >
-      <h2 className={cx(styles.label)}>{categoryName}</h2>
+      <h2 className={cx(styles.label)}>{name}</h2>
       <div className={cx(styles.categoryContent)}>{children}</div>
     </li>
   );

--- a/src/components/body/EmojiList.tsx
+++ b/src/components/body/EmojiList.tsx
@@ -5,8 +5,7 @@ import { ClassNames } from '../../DomUtils/classNames';
 import { stylesheet } from '../../Stylesheet/stylesheet';
 import {
   Category,
-  CategoryConfig,
-  categoryFromCategoryConfig
+  CategoryConfig
 } from '../../config/categoryConfig';
 import {
   useCategoriesConfig,
@@ -34,7 +33,7 @@ export function EmojiList() {
   return (
     <ul className={cx(styles.emojiList)}>
       {categories.map(categoryConfig => {
-        const category = categoryFromCategoryConfig(categoryConfig);
+        const category = categoryConfig.category
 
         if (category === 'suggested') {
           return <Suggested key={category} categoryConfig={categoryConfig} />;

--- a/src/components/body/EmojiList.tsx
+++ b/src/components/body/EmojiList.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { ClassNames } from '../../DomUtils/classNames';
 import { stylesheet } from '../../Stylesheet/stylesheet';
 import {
-  Categories,
+  Category,
   CategoryConfig,
   categoryFromCategoryConfig
 } from '../../config/categoryConfig';
@@ -36,7 +36,7 @@ export function EmojiList() {
       {categories.map(categoryConfig => {
         const category = categoryFromCategoryConfig(categoryConfig);
 
-        if (category === Categories.SUGGESTED) {
+        if (category === 'suggested') {
           return <Suggested key={category} categoryConfig={categoryConfig} />;
         }
 
@@ -59,7 +59,7 @@ function RenderCategory({
   categoryConfig,
   renderdCategoriesCountRef
 }: {
-  category: Categories;
+  category: Category;
   categoryConfig: CategoryConfig;
   renderdCategoriesCountRef: React.MutableRefObject<number>;
 }) {

--- a/src/components/emoji/BaseEmojiProps.ts
+++ b/src/components/emoji/BaseEmojiProps.ts
@@ -1,6 +1,6 @@
 import { CustomEmoji } from '../../config/customEmojiConfig';
 import { DataEmoji } from '../../dataUtils/DataTypes';
-import { EmojiStyle } from '../../types/exposedTypes';
+import { EmojiStyle } from '../../types/public';
 
 export type BaseEmojiProps = {
   emoji?: DataEmoji | CustomEmoji;

--- a/src/components/emoji/EmojiImg.tsx
+++ b/src/components/emoji/EmojiImg.tsx
@@ -2,7 +2,7 @@ import { cx } from 'flairup';
 import * as React from 'react';
 
 import { stylesheet } from '../../Stylesheet/stylesheet';
-import { EmojiStyle } from '../../types/exposedTypes';
+import { EmojiStyle } from '../../types/public';
 
 import { emojiStyles } from './emojiStyles';
 

--- a/src/components/emoji/ExportedEmoji.tsx
+++ b/src/components/emoji/ExportedEmoji.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
-import { EmojiStyle } from '../../types/exposedTypes';
+
+import { EmojiStyle } from '../../types/public';
 
 import { GetEmojiUrl } from './BaseEmojiProps';
 import { ViewOnlyEmoji } from './ViewOnlyEmoji';
@@ -8,7 +9,7 @@ import { ViewOnlyEmoji } from './ViewOnlyEmoji';
 export function ExportedEmoji({
   unified,
   size = 32,
-  emojiStyle = EmojiStyle.APPLE,
+  emojiStyle = 'apple',
   lazyLoad = false,
   getEmojiUrl,
   emojiUrl

--- a/src/components/emoji/ViewOnlyEmoji.tsx
+++ b/src/components/emoji/ViewOnlyEmoji.tsx
@@ -6,7 +6,6 @@ import {
   emojiUrlByUnified
 } from '../../dataUtils/emojiSelectors';
 import { isCustomEmoji } from '../../typeRefinements/typeRefinements';
-import { EmojiStyle } from '../../types/exposedTypes';
 import { useEmojisThatFailedToLoadState } from '../context/PickerContext';
 
 import { BaseEmojiProps } from './BaseEmojiProps';
@@ -40,7 +39,7 @@ export function ViewOnlyEmoji({
       <EmojiImg
         style={style}
         emojiName={unified}
-        emojiStyle={EmojiStyle.NATIVE}
+        emojiStyle={'native'}
         lazyLoad={lazyLoad}
         imgUrl={emojiToRender.imgUrl}
         onError={onError}
@@ -51,7 +50,7 @@ export function ViewOnlyEmoji({
 
   return (
     <>
-      {emojiStyle === EmojiStyle.NATIVE ? (
+      {emojiStyle === 'native' ? (
         <NativeEmoji unified={unified} style={style} className={className} />
       ) : (
         <EmojiImg

--- a/src/components/main/PickerMain.tsx
+++ b/src/components/main/PickerMain.tsx
@@ -11,7 +11,6 @@ import {
 import useIsSearchMode from '../../hooks/useIsSearchMode';
 import { useKeyboardNavigation } from '../../hooks/useKeyboardNavigation';
 import { useOnFocus } from '../../hooks/useOnFocus';
-import { Theme } from '../../types/exposedTypes';
 import { usePickerMainRef } from '../context/ElementRefContext';
 import {
   PickerContextProvider,
@@ -56,8 +55,8 @@ function PickerRootElement({ children }: RootProps) {
       className={cx(
         styles.main,
         styles.baseVariables,
-        theme === Theme.DARK && styles.darkTheme,
-        theme === Theme.AUTO && styles.autoThemeDark,
+        theme === 'dark' && styles.darkTheme,
+        theme === 'auto' && styles.autoThemeDark,
         {
           [ClassNames.searchActive]: searchModeActive
         },

--- a/src/components/navigation/CategoryButton.tsx
+++ b/src/components/navigation/CategoryButton.tsx
@@ -7,10 +7,7 @@ import {
   darkMode,
   stylesheet
 } from '../../Stylesheet/stylesheet';
-import {
-  CategoryConfig,
-  categoryNameFromCategoryConfig
-} from '../../config/categoryConfig';
+import { CategoryConfig } from '../../config/categoryConfig';
 import { Button } from '../atoms/Button';
 
 import SVGNavigation from './svg/CategoryNav.svg';
@@ -42,7 +39,7 @@ export function CategoryButton({
         }
       )}
       onClick={onClick}
-      aria-label={categoryNameFromCategoryConfig(categoryConfig)}
+      aria-label={categoryConfig.name}
       aria-selected={isActiveCategory}
       role="tab"
       aria-controls="epr-category-nav-id"

--- a/src/components/navigation/CategoryNavigation.tsx
+++ b/src/components/navigation/CategoryNavigation.tsx
@@ -9,7 +9,6 @@ import { useActiveCategoryScrollDetection } from '../../hooks/useActiveCategoryS
 import useIsSearchMode from '../../hooks/useIsSearchMode';
 import { useScrollCategoryIntoView } from '../../hooks/useScrollCategoryIntoView';
 import { useShouldHideCustomEmojis } from '../../hooks/useShouldHideCustomEmojis';
-import { isCustomCategory } from '../../typeRefinements/typeRefinements';
 import { useCategoryNavigationRef } from '../context/ElementRefContext';
 
 import { CategoryButton } from './CategoryButton';
@@ -34,11 +33,14 @@ export function CategoryNavigation() {
     >
       {categoriesConfig.map(categoryConfig => {
         const category = categoryFromCategoryConfig(categoryConfig);
-        const isActiveCategory = category === activeCategory;
 
-        if (isCustomCategory(categoryConfig) && hideCustomCategory) {
+        const isSkippedCustom = hideCustomCategory && category === 'custom'
+        if (isSkippedCustom) {
           return null;
         }
+
+        const isActiveCategory = category === activeCategory;
+
 
         const allowNavigation = !isSearchMode && !isActiveCategory;
 

--- a/src/components/navigation/CategoryNavigation.tsx
+++ b/src/components/navigation/CategoryNavigation.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { useState } from 'react';
 
 import { stylesheet } from '../../Stylesheet/stylesheet';
-import { categoryFromCategoryConfig } from '../../config/categoryConfig';
 import { useCategoriesConfig } from '../../config/useConfig';
 import { useActiveCategoryScrollDetection } from '../../hooks/useActiveCategoryScrollDetection';
 import useIsSearchMode from '../../hooks/useIsSearchMode';
@@ -32,7 +31,7 @@ export function CategoryNavigation() {
       ref={CategoryNavigationRef}
     >
       {categoriesConfig.map(categoryConfig => {
-        const category = categoryFromCategoryConfig(categoryConfig);
+        const category = categoryConfig.category
 
         const isSkippedCustom = hideCustomCategory && category === 'custom'
         if (isSkippedCustom) {

--- a/src/config/categoryConfig.ts
+++ b/src/config/categoryConfig.ts
@@ -1,4 +1,5 @@
-import { Categories, SuggestionMode } from '../types/exposedTypes';
+import { Categories } from '../types/exposedTypes';
+import { SuggestionMode } from '../types/public';
 
 export { Categories };
 
@@ -102,7 +103,7 @@ export function mergeCategoriesConfig(
 ): CategoriesConfig {
   const extra = {} as Record<Categories, CategoryConfig>;
 
-  if (modifiers.suggestionMode === SuggestionMode.RECENT) {
+  if (modifiers.suggestionMode === 'recent') {
     extra[Categories.SUGGESTED] = SuggestedRecent;
   }
 

--- a/src/config/categoryConfig.ts
+++ b/src/config/categoryConfig.ts
@@ -1,78 +1,72 @@
-import { Categories } from '../types/exposedTypes';
 import { SuggestionMode } from '../types/public';
 
-export { Categories };
+const CATEGORIES = [
+  'suggested',
+  'custom',
+  'smileys_people',
+  'animals_nature',
+  'food_drink',
+  'travel_places',
+  'activities',
+  'objects',
+  'symbols',
+  'flags'
+] as const;
 
-const categoriesOrdered: Categories[] = [
-  Categories.SUGGESTED,
-  Categories.CUSTOM,
-  Categories.SMILEYS_PEOPLE,
-  Categories.ANIMALS_NATURE,
-  Categories.FOOD_DRINK,
-  Categories.TRAVEL_PLACES,
-  Categories.ACTIVITIES,
-  Categories.OBJECTS,
-  Categories.SYMBOLS,
-  Categories.FLAGS
-];
+export type Category = typeof CATEGORIES[number];
 
 export const SuggestedRecent: CategoryConfig = {
   name: 'Recently Used',
-  category: Categories.SUGGESTED
+  category: 'suggested'
 };
 
-export type CustomCategoryConfig = {
-  category: Categories.CUSTOM;
-  name: string;
-};
-
-const configByCategory: Record<Categories, CategoryConfig> = {
-  [Categories.SUGGESTED]: {
-    category: Categories.SUGGESTED,
+const configByCategory: Record<Category, CategoryConfig> = {
+  suggested: {
+    category: 'suggested',
     name: 'Frequently Used'
   },
-  [Categories.CUSTOM]: {
-    category: Categories.CUSTOM,
+  custom: {
+    category: 'custom',
     name: 'Custom Emojis'
   },
-  [Categories.SMILEYS_PEOPLE]: {
-    category: Categories.SMILEYS_PEOPLE,
+  smileys_people: {
+    category: 'smileys_people',
     name: 'Smileys & People'
   },
-  [Categories.ANIMALS_NATURE]: {
-    category: Categories.ANIMALS_NATURE,
+  animals_nature: {
+    category: 'animals_nature',
     name: 'Animals & Nature'
   },
-  [Categories.FOOD_DRINK]: {
-    category: Categories.FOOD_DRINK,
+  food_drink: {
+    category: 'food_drink',
     name: 'Food & Drink'
   },
-  [Categories.TRAVEL_PLACES]: {
-    category: Categories.TRAVEL_PLACES,
+  travel_places: {
+    category: 'travel_places',
     name: 'Travel & Places'
   },
-  [Categories.ACTIVITIES]: {
-    category: Categories.ACTIVITIES,
+  activities: {
+    category: 'activities',
     name: 'Activities'
   },
-  [Categories.OBJECTS]: {
-    category: Categories.OBJECTS,
+  objects: {
+    category: 'objects',
     name: 'Objects'
   },
-  [Categories.SYMBOLS]: {
-    category: Categories.SYMBOLS,
+  symbols: {
+    category: 'symbols',
     name: 'Symbols'
   },
-  [Categories.FLAGS]: {
-    category: Categories.FLAGS,
+  flags: {
+    category: 'flags',
     name: 'Flags'
   }
 };
 
 export function baseCategoriesConfig(
-  modifiers?: Record<Categories, CategoryConfig>
+  modifiers?: Record<Category, CategoryConfig>
 ): CategoriesConfig {
-  return categoriesOrdered.map(category => {
+  return CATEGORIES.map(category => {
     return {
       ...configByCategory[category],
       ...(modifiers && modifiers[category] && modifiers[category])
@@ -91,20 +85,20 @@ export function categoryNameFromCategoryConfig(category: CategoryConfig) {
 export type CategoriesConfig = CategoryConfig[];
 
 export type CategoryConfig = {
-  category: Categories;
+  category: Category;
   name: string;
 };
 
-export type UserCategoryConfig = Array<Categories | CategoryConfig>;
+export type UserCategoryConfig = Array<Category | CategoryConfig>;
 
 export function mergeCategoriesConfig(
   userCategoriesConfig: UserCategoryConfig = [],
   modifiers: CategoryConfigModifiers = {}
 ): CategoriesConfig {
-  const extra = {} as Record<Categories, CategoryConfig>;
+  const extra = {} as Record<Category, CategoryConfig>;
 
   if (modifiers.suggestionMode === 'recent') {
-    extra[Categories.SUGGESTED] = SuggestedRecent;
+    extra['suggested'] = SuggestedRecent;
   }
 
   const base = baseCategoriesConfig(extra);
@@ -125,7 +119,7 @@ export function mergeCategoriesConfig(
 }
 
 function getBaseConfigByCategory(
-  category: Categories,
+  category: Category,
   modifier: CategoryConfig = {} as CategoryConfig
 ) {
   return Object.assign(configByCategory[category], modifier);

--- a/src/config/categoryConfig.ts
+++ b/src/config/categoryConfig.ts
@@ -74,14 +74,6 @@ export function baseCategoriesConfig(
   });
 }
 
-export function categoryFromCategoryConfig(category: CategoryConfig) {
-  return category.category;
-}
-
-export function categoryNameFromCategoryConfig(category: CategoryConfig) {
-  return category.name;
-}
-
 export type CategoriesConfig = CategoryConfig[];
 
 export type CategoryConfig = {

--- a/src/config/cdnUrls.ts
+++ b/src/config/cdnUrls.ts
@@ -1,24 +1,13 @@
-import { EmojiStyle } from '../types/exposedTypes';
+import { EmojiStyle } from '../types/public';
 
-const CDN_URL_APPLE =
-  'https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/';
-const CDN_URL_FACEBOOK =
-  'https://cdn.jsdelivr.net/npm/emoji-datasource-facebook/img/facebook/64/';
-const CDN_URL_TWITTER =
-  'https://cdn.jsdelivr.net/npm/emoji-datasource-twitter/img/twitter/64/';
-const CDN_URL_GOOGLE =
-  'https://cdn.jsdelivr.net/npm/emoji-datasource-google/img/google/64/';
+const CDN: Partial<Record<EmojiStyle, string>> = {
+  apple: 'https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/',
+  facebook:
+    'https://cdn.jsdelivr.net/npm/emoji-datasource-facebook/img/facebook/64/',
+  twitter:
+    'https://cdn.jsdelivr.net/npm/emoji-datasource-twitter/img/twitter/64/',
+  google: 'https://cdn.jsdelivr.net/npm/emoji-datasource-google/img/google/64/'
+};
 
-export function cdnUrl(emojiStyle: EmojiStyle): string {
-  switch (emojiStyle) {
-    case EmojiStyle.TWITTER:
-      return CDN_URL_TWITTER;
-    case EmojiStyle.GOOGLE:
-      return CDN_URL_GOOGLE;
-    case EmojiStyle.FACEBOOK:
-      return CDN_URL_FACEBOOK;
-    case EmojiStyle.APPLE:
-    default:
-      return CDN_URL_APPLE;
-  }
-}
+export const cdnUrl = (emojiStyle: EmojiStyle): string =>
+  CDN[emojiStyle]! ?? CDN.apple;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -9,11 +9,11 @@ import {
 import {
   EmojiClickData,
   EmojiStyle,
-  SkinTonePickerLocation,
   SkinTones,
   SuggestionMode,
   Theme
 } from '../types/exposedTypes';
+import type { SkinTonePickerLocation } from '../types/public';
 
 import {
   CategoriesConfig,
@@ -55,7 +55,7 @@ export function mergeConfig(
   setCustomEmojis(config.customEmojis ?? []);
 
   const skinTonePickerLocation = config.searchDisabled
-    ? SkinTonePickerLocation.PREVIEW
+    ? 'PREVIEW'
     : config.skinTonePickerLocation;
 
   return {
@@ -84,7 +84,7 @@ export function basePickerConfig(): PickerConfigInternal {
     searchDisabled: false,
     searchPlaceHolder: DEFAULT_SEARCH_PLACEHOLDER,
     searchPlaceholder: DEFAULT_SEARCH_PLACEHOLDER,
-    skinTonePickerLocation: SkinTonePickerLocation.SEARCH,
+    skinTonePickerLocation: 'SEARCH',
     skinTonesDisabled: false,
     style: {},
     suggestedEmojisMode: SuggestionMode.FREQUENT,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -8,11 +8,9 @@ import {
 } from '../dataUtils/emojiSelectors';
 import {
   EmojiClickData,
-  EmojiStyle,
-  SkinTones,
-  Theme
+  SkinTones
 } from '../types/exposedTypes';
-import type { SkinTonePickerLocation, SuggestionMode } from '../types/public';
+import type { EmojiStyle, SkinTonePickerLocation, SuggestionMode, Theme } from '../types/public';
 
 import {
   CategoriesConfig,
@@ -72,7 +70,7 @@ export function basePickerConfig(): PickerConfigInternal {
     className: '',
     customEmojis: [],
     defaultSkinTone: SkinTones.NEUTRAL,
-    emojiStyle: EmojiStyle.APPLE,
+    emojiStyle: 'apple',
     emojiVersion: null,
     getEmojiUrl: emojiUrlByUnified,
     height: 450,
@@ -87,7 +85,7 @@ export function basePickerConfig(): PickerConfigInternal {
     skinTonesDisabled: false,
     style: {},
     suggestedEmojisMode: 'frequent',
-    theme: Theme.LIGHT,
+    theme: 'light',
     unicodeToHide: new Set<string>(KNOWN_FAILING_EMOJIS),
     width: 350,
     reactionsDefaultOpen: false,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -10,10 +10,9 @@ import {
   EmojiClickData,
   EmojiStyle,
   SkinTones,
-  SuggestionMode,
   Theme
 } from '../types/exposedTypes';
-import type { SkinTonePickerLocation } from '../types/public';
+import type { SkinTonePickerLocation, SuggestionMode } from '../types/public';
 
 import {
   CategoriesConfig,
@@ -87,7 +86,7 @@ export function basePickerConfig(): PickerConfigInternal {
     skinTonePickerLocation: 'SEARCH',
     skinTonesDisabled: false,
     style: {},
-    suggestedEmojisMode: SuggestionMode.FREQUENT,
+    suggestedEmojisMode: 'frequent',
     theme: Theme.LIGHT,
     unicodeToHide: new Set<string>(KNOWN_FAILING_EMOJIS),
     width: 350,

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -5,10 +5,9 @@ import {
   EmojiClickData,
   EmojiStyle,
   SkinTones,
-  SuggestionMode,
   Theme
 } from '../types/exposedTypes';
-import { SkinTonePickerLocation } from '../types/public';
+import { SkinTonePickerLocation, SuggestionMode } from '../types/public';
 
 import { CategoriesConfig } from './categoryConfig';
 import {

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -4,11 +4,11 @@ import { usePickerConfig } from '../components/context/PickerConfigContext';
 import {
   EmojiClickData,
   EmojiStyle,
-  SkinTonePickerLocation,
   SkinTones,
   SuggestionMode,
   Theme
 } from '../types/exposedTypes';
+import { SkinTonePickerLocation } from '../types/public';
 
 import { CategoriesConfig } from './categoryConfig';
 import {

--- a/src/config/useConfig.ts
+++ b/src/config/useConfig.ts
@@ -3,11 +3,9 @@ import * as React from 'react';
 import { usePickerConfig } from '../components/context/PickerConfigContext';
 import {
   EmojiClickData,
-  EmojiStyle,
-  SkinTones,
-  Theme
+  SkinTones
 } from '../types/exposedTypes';
-import { SkinTonePickerLocation, SuggestionMode } from '../types/public';
+import { EmojiStyle, SkinTonePickerLocation, SuggestionMode, Theme } from '../types/public';
 
 import { CategoriesConfig } from './categoryConfig';
 import {

--- a/src/dataUtils/emojiSelectors.ts
+++ b/src/dataUtils/emojiSelectors.ts
@@ -1,11 +1,11 @@
-import { Categories } from '../config/categoryConfig';
 import { cdnUrl } from '../config/cdnUrls';
 import { CustomEmoji } from '../config/customEmojiConfig';
 import emojis from '../data/emojis';
 import skinToneVariations, {
   skinTonesMapped
 } from '../data/skinToneVariations';
-import { EmojiStyle, SkinTones } from '../types/exposedTypes';
+import { SkinTones } from '../types/exposedTypes';
+import { Category, EmojiStyle } from '../types/public';
 
 import { DataEmoji, DataEmojis, EmojiProperties, WithName } from './DataTypes';
 import { indexEmoji } from './alphaNumericEmojiIndex';
@@ -47,7 +47,7 @@ export function emojiUnified(emoji: DataEmoji, skinTone?: string): string {
   return emojiVariationUnified(emoji, skinTone) ?? unified;
 }
 
-export function emojisByCategory(category: Categories): DataEmojis {
+export function emojisByCategory(category: Category): DataEmojis {
   // @ts-ignore
   return emojis?.[category] ?? [];
 }
@@ -93,12 +93,12 @@ export function emojiByUnified(unified?: string): DataEmoji | undefined {
 export const allEmojis: DataEmojis = Object.values(emojis).flat();
 
 export function setCustomEmojis(customEmojis: CustomEmoji[]): void {
-  emojis[Categories.CUSTOM].length = 0;
+  emojis.custom.length = 0;
 
   customEmojis.forEach(emoji => {
     const emojiData = customToRegularEmoji(emoji);
 
-    emojis[Categories.CUSTOM].push(emojiData as never);
+    emojis.custom.push(emojiData as never);
 
     if (allEmojisByUnified[emojiData[EmojiProperties.unified]]) {
       return;

--- a/src/dataUtils/suggested.ts
+++ b/src/dataUtils/suggested.ts
@@ -1,4 +1,5 @@
-import { SkinTones, SuggestionMode } from '../types/exposedTypes';
+import { SkinTones } from '../types/exposedTypes';
+import { SuggestionMode } from '../types/public';
 
 import { DataEmoji } from './DataTypes';
 import { emojiUnified } from './emojiSelectors';
@@ -22,7 +23,7 @@ export function getSuggested(mode?: SuggestionMode): Suggested {
       window?.localStorage.getItem(SUGGESTED_LS_KEY) ?? '[]'
     ) as Suggested;
 
-    if (mode === SuggestionMode.FREQUENT) {
+    if (mode === 'frequent') {
       return recent.sort((a, b) => b.count - a.count);
     }
 

--- a/src/hooks/preloadEmoji.ts
+++ b/src/hooks/preloadEmoji.ts
@@ -1,7 +1,7 @@
 import { GetEmojiUrl } from '../components/emoji/BaseEmojiProps';
 import { DataEmoji } from '../dataUtils/DataTypes';
 import { emojiUnified, emojiVariations } from '../dataUtils/emojiSelectors';
-import { EmojiStyle } from '../types/exposedTypes';
+import { EmojiStyle } from '../types/public';
 
 export function preloadEmoji(
   getEmojiUrl: GetEmojiUrl,
@@ -12,7 +12,7 @@ export function preloadEmoji(
     return;
   }
 
-  if (emojiStyle === EmojiStyle.NATIVE) {
+  if (emojiStyle === 'native') {
     return;
   }
 
@@ -22,7 +22,7 @@ export function preloadEmoji(
     return;
   }
 
-  emojiVariations(emoji).forEach((variation) => {
+  emojiVariations(emoji).forEach(variation => {
     const emojiUrl = getEmojiUrl(variation, emojiStyle);
     preloadImage(emojiUrl);
   });

--- a/src/hooks/useMouseDownHandlers.ts
+++ b/src/hooks/useMouseDownHandlers.ts
@@ -29,7 +29,8 @@ import {
 import { parseNativeEmoji } from '../dataUtils/parseNativeEmoji';
 import { setSuggested } from '../dataUtils/suggested';
 import { isCustomEmoji } from '../typeRefinements/typeRefinements';
-import { EmojiClickData, SkinTones, EmojiStyle } from '../types/exposedTypes';
+import { EmojiClickData, SkinTones } from '../types/exposedTypes';
+import { EmojiStyle } from '../types/public';
 
 import { useCloseAllOpenToggles } from './useCloseAllOpenToggles';
 import useSetVariationPicker from './useSetVariationPicker';
@@ -192,10 +193,10 @@ function emojiClickOutput(
   return {
     activeSkinTone,
     emoji: parseNativeEmoji(unified),
-    getImageUrl(emojiStyle: EmojiStyle = activeEmojiStyle ?? EmojiStyle.APPLE) {
+    getImageUrl(emojiStyle: EmojiStyle = activeEmojiStyle ?? 'apple') {
       return getEmojiUrl(unified, emojiStyle);
     },
-    imageUrl: getEmojiUrl(unified, activeEmojiStyle ?? EmojiStyle.APPLE),
+    imageUrl: getEmojiUrl(unified, activeEmojiStyle ?? 'apple'),
     isCustom: false,
     names,
     unified,

--- a/src/hooks/useOnFocus.ts
+++ b/src/hooks/useOnFocus.ts
@@ -4,7 +4,6 @@ import { buttonFromTarget, emojiFromElement } from '../DomUtils/selectors';
 import { useBodyRef } from '../components/context/ElementRefContext';
 import { useEmojiStyleConfig, useGetEmojiUrlConfig } from '../config/useConfig';
 import { emojiHasVariations } from '../dataUtils/emojiSelectors';
-import { EmojiStyle } from '../types/exposedTypes';
 
 import { preloadEmoji } from './preloadEmoji';
 
@@ -14,7 +13,7 @@ export function useOnFocus() {
   const getEmojiUrl = useGetEmojiUrlConfig();
 
   useEffect(() => {
-    if (emojiStyle === EmojiStyle.NATIVE) {
+    if (emojiStyle === 'native') {
       return;
     }
 

--- a/src/hooks/useShouldShowSkinTonePicker.ts
+++ b/src/hooks/useShouldShowSkinTonePicker.ts
@@ -1,5 +1,5 @@
 import { useSkinTonePickerLocationConfig } from '../config/useConfig';
-import { SkinTonePickerLocation } from '../types/exposedTypes';
+import { SkinTonePickerLocation } from '../types/public';
 
 export function useShouldShowSkinTonePicker() {
   const skinTonePickerLocationConfig = useSkinTonePickerLocationConfig();
@@ -12,11 +12,11 @@ export function useShouldShowSkinTonePicker() {
 export function useIsSkinToneInSearch() {
   const skinTonePickerLocationConfig = useSkinTonePickerLocationConfig();
 
-  return skinTonePickerLocationConfig === SkinTonePickerLocation.SEARCH;
+  return skinTonePickerLocationConfig === 'SEARCH';
 }
 
 export function useIsSkinToneInPreview() {
   const skinTonePickerLocationConfig = useSkinTonePickerLocationConfig();
 
-  return skinTonePickerLocationConfig === SkinTonePickerLocation.PREVIEW;
+  return skinTonePickerLocationConfig === 'PREVIEW';
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,7 @@ export {
   SkinTonePickerLocation
 } from './types/exposedTypes';
 
+export type * as EmojiPickerReact from './types/public';
 export interface PickerProps extends PickerConfig {}
 
 export default function EmojiPicker(props: PickerProps) {

--- a/src/typeRefinements/typeRefinements.ts
+++ b/src/typeRefinements/typeRefinements.ts
@@ -1,16 +1,5 @@
-import {
-  Categories,
-  CategoryConfig,
-  CustomCategoryConfig
-} from '../config/categoryConfig';
 import { CustomEmoji } from '../config/customEmojiConfig';
 import { DataEmoji } from '../dataUtils/DataTypes';
-
-export function isCustomCategory(
-  category: CategoryConfig | CustomCategoryConfig
-): category is CustomCategoryConfig {
-  return category.category === Categories.CUSTOM;
-}
 
 export function isCustomEmoji(emoji: Partial<DataEmoji>): emoji is CustomEmoji {
   return emoji.imgUrl !== undefined;

--- a/src/types/exposedTypes.ts
+++ b/src/types/exposedTypes.ts
@@ -1,3 +1,5 @@
+import type * as EmojiPickerReact from './public';
+
 export type EmojiClickData = {
   activeSkinTone: SkinTones;
   unified: string;
@@ -5,7 +7,7 @@ export type EmojiClickData = {
   emoji: string;
   names: string[];
   imageUrl: string;
-  getImageUrl: (emojiStyle?: EmojiStyle) => string;
+  getImageUrl: (emojiStyle?: EmojiPickerReact.EmojiStyle) => string;
   isCustom: boolean;
 };
 
@@ -15,6 +17,7 @@ export enum SuggestionMode {
   FREQUENT = 'frequent'
 }
 
+/** @deprecated consider use plain string values or use `EmojiPickerReact.EmojiStyle` as type */
 export enum EmojiStyle {
   NATIVE = 'native',
   APPLE = 'apple',
@@ -23,6 +26,7 @@ export enum EmojiStyle {
   FACEBOOK = 'facebook'
 }
 
+/** @deprecated consider use plain string values or use `EmojiPickerReact.Theme` as type */
 export enum Theme {
   DARK = 'dark',
   LIGHT = 'light',
@@ -38,6 +42,7 @@ export enum SkinTones {
   DARK = '1f3ff'
 }
 
+/** @deprecated consider use plain string values or use `EmojiPickerReact.Category` as type */
 export enum Categories {
   SUGGESTED = 'suggested',
   CUSTOM = 'custom',

--- a/src/types/exposedTypes.ts
+++ b/src/types/exposedTypes.ts
@@ -9,6 +9,7 @@ export type EmojiClickData = {
   isCustom: boolean;
 };
 
+/** @deprecated consider use plain string values or use `EmojiPickerReact.SuggestionMode` as type */
 export enum SuggestionMode {
   RECENT = 'recent',
   FREQUENT = 'frequent'
@@ -50,6 +51,7 @@ export enum Categories {
   FLAGS = 'flags'
 }
 
+/** @deprecated consider use plain string values or use `EmojiPickerReact.SkinTonePickerLocation` as type */
 export enum SkinTonePickerLocation {
   SEARCH = 'SEARCH',
   PREVIEW = 'PREVIEW'

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -1,4 +1,23 @@
+export type { Category } from "../config/categoryConfig";
+
 type SkinTonePickerLocation = 'SEARCH' | 'PREVIEW';
 type SuggestionMode = 'recent' | 'frequent';
 
-export type { SkinTonePickerLocation, SuggestionMode }
+type EmojiStyle =
+  | 'native'
+  | 'apple'
+  | 'twitter'
+  | 'google'
+  | 'facebook';
+
+type Theme =
+  | 'dark'
+  | 'light'
+  | 'auto'
+
+export type {
+  EmojiStyle,
+  SkinTonePickerLocation,
+  SuggestionMode,
+  Theme
+}

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -1,0 +1,1 @@
+export type SkinTonePickerLocation = 'SEARCH' | 'PREVIEW';

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -1,1 +1,4 @@
-export type SkinTonePickerLocation = 'SEARCH' | 'PREVIEW';
+type SkinTonePickerLocation = 'SEARCH' | 'PREVIEW';
+type SuggestionMode = 'recent' | 'frequent';
+
+export type { SkinTonePickerLocation, SuggestionMode }

--- a/stories/picker.stories.tsx
+++ b/stories/picker.stories.tsx
@@ -4,11 +4,11 @@ import React, { useEffect, useState } from 'react';
 import EmojiPicker, {
   Emoji,
   EmojiStyle,
-  Props,
+  PickerProps,
   SkinTones,
-  Theme
+  Theme,
+  Categories
 } from '../src';
-import { Categories } from '../src/config/categoryConfig';
 import {
   EmojiClickData,
   SkinTonePickerLocation,
@@ -32,22 +32,22 @@ const meta: Meta = {
 
 export default meta;
 
-export const Native = (args: Props) => (
+export const Native = (args: PickerProps) => (
   <Template {...args} emojiStyle={EmojiStyle.NATIVE} />
 );
-export const Default = (args: Props) => <Template {...args} />;
-export const Dark = (args: Props) => (
+export const Default = (args: PickerProps) => <Template {...args} />;
+export const Dark = (args: PickerProps) => (
   <TemplateDark {...args} theme={Theme.DARK} />
 );
-export const AutoTheme = (args: Props) => (
+export const AutoTheme = (args: PickerProps) => (
   <TemplateDark {...args} theme={Theme.AUTO} />
 );
 
-export const CustomEmojis = (args: Props) => (
+export const CustomEmojis = (args: PickerProps) => (
   <Template {...args} customEmojis={customEmojis} />
 );
 
-export const CustomEmojisDeffered = (args: Props) => {
+export const CustomEmojisDeffered = (args: PickerProps) => {
   const [custom, setCustomEmojis] = useState<any>(undefined);
 
   useEffect(() => {
@@ -59,26 +59,26 @@ export const CustomEmojisDeffered = (args: Props) => {
   return <Template {...args} customEmojis={custom} />;
 };
 
-export const SearchDisabled = (args: Props) => (
+export const SearchDisabled = (args: PickerProps) => (
   <Template {...args} searchDisabled />
 );
 
-export const HiddenEmojis = (args: Props) => (
+export const HiddenEmojis = (args: PickerProps) => (
   <Template {...args} hiddenEmojis={['1f604', '1f60d', '1f607']} />
 );
 
-export const SearchDisabledDark = (args: Props) => (
+export const SearchDisabledDark = (args: PickerProps) => (
   <TemplateDark {...args} searchDisabled theme={Theme.DARK} />
 );
 
-export const SkinTonePickerInPreview = (args: Props) => (
+export const SkinTonePickerInPreview = (args: PickerProps) => (
   <Template
     {...args}
     emojiStyle={EmojiStyle.NATIVE}
     skinTonePickerLocation={SkinTonePickerLocation.PREVIEW}
   />
 );
-export const CustomSizeDimensionsNumbers = (args: Props) => (
+export const CustomSizeDimensionsNumbers = (args: PickerProps) => (
   <TemplateDark
     {...args}
     width={300}
@@ -87,7 +87,7 @@ export const CustomSizeDimensionsNumbers = (args: Props) => (
   />
 );
 
-export const CustomSizeDimensionsString = (args: Props) => (
+export const CustomSizeDimensionsString = (args: PickerProps) => (
   <TemplateDark
     {...args}
     width="80vh"
@@ -95,41 +95,41 @@ export const CustomSizeDimensionsString = (args: Props) => (
     previewConfig={{ showPreview: false }}
   />
 );
-export const EmojiImageApple = (args: Props) => (
+export const EmojiImageApple = (args: PickerProps) => (
   <Template {...args} emojiStyle={EmojiStyle.APPLE} />
 );
-export const EmojiImageFacebook = (args: Props) => (
+export const EmojiImageFacebook = (args: PickerProps) => (
   <Template {...args} emojiStyle={EmojiStyle.FACEBOOK} />
 );
-export const EmojiImageGoogle = (args: Props) => (
+export const EmojiImageGoogle = (args: PickerProps) => (
   <Template {...args} emojiStyle={EmojiStyle.GOOGLE} />
 );
-export const EmojiImageTwitter = (args: Props) => (
+export const EmojiImageTwitter = (args: PickerProps) => (
   <Template {...args} emojiStyle={EmojiStyle.TWITTER} />
 );
-export const CustomSearchPlaceholder = (args: Props) => (
+export const CustomSearchPlaceholder = (args: PickerProps) => (
   <Template searchPlaceholder="👀 Find" />
 );
-export const SkinTonesDisabled = (args: Props) => (
+export const SkinTonesDisabled = (args: PickerProps) => (
   <Template {...args} skinTonesDisabled />
 );
-export const AlternativeDefaultSkinTone = (args: Props) => (
+export const AlternativeDefaultSkinTone = (args: PickerProps) => (
   <Template {...args} defaultSkinTone={SkinTones.MEDIUM} />
 );
-export const AutoFocusDisabled = (args: Props) => (
+export const AutoFocusDisabled = (args: PickerProps) => (
   <Template {...args} autoFocusSearch={false} />
 );
-export const HidePreview = (args: Props) => (
+export const HidePreview = (args: PickerProps) => (
   <Template {...args} previewConfig={{ showPreview: false }} />
 );
-export const RecentlyUsed = (args: Props) => (
+export const RecentlyUsed = (args: PickerProps) => (
   <Template {...args} suggestedEmojisMode={SuggestionMode.RECENT} />
 );
-export const LazyLoaded = (args: Props) => (
+export const LazyLoaded = (args: PickerProps) => (
   <Template {...args} lazyLoadEmojis={true} />
 );
 
-export const SkinToneChange = (args: Props) => (
+export const SkinToneChange = (args: PickerProps) => (
   <Template
     {...args}
     onSkinToneChange={skinTone => {
@@ -138,7 +138,7 @@ export const SkinToneChange = (args: Props) => (
   />
 );
 
-export const ReactionsMenu = (args: Props) => (
+export const ReactionsMenu = (args: PickerProps) => (
   <Template
     {...args}
     reactionsDefaultOpen={true}
@@ -148,7 +148,7 @@ export const ReactionsMenu = (args: Props) => (
   />
 );
 
-export const ReactionsMenuNoExpand = (args: Props) => (
+export const ReactionsMenuNoExpand = (args: PickerProps) => (
   <Template
     {...args}
     reactionsDefaultOpen={true}
@@ -159,7 +159,7 @@ export const ReactionsMenuNoExpand = (args: Props) => (
   />
 );
 
-export const ReactionsMenuWithStyles = (args: Props) => (
+export const ReactionsMenuWithStyles = (args: PickerProps) => (
   <Template
     {...args}
     reactionsDefaultOpen={true}
@@ -172,7 +172,7 @@ export const ReactionsMenuWithStyles = (args: Props) => (
   />
 );
 
-export const CustomReactions = (args: Props) => (
+export const CustomReactions = (args: PickerProps) => (
   <Template
     {...args}
     reactionsDefaultOpen={true}
@@ -186,15 +186,15 @@ export const CustomReactions = (args: Props) => (
   />
 );
 
-export const ReactionsMenuDark = (args: Props) => (
+export const ReactionsMenuDark = (args: PickerProps) => (
   <TemplateDark {...args} reactionsDefaultOpen={true} theme={Theme.DARK} />
 );
 
-export const ReactionsMenuAuto = (args: Props) => (
+export const ReactionsMenuAuto = (args: PickerProps) => (
   <Template {...args} reactionsDefaultOpen={true} theme={Theme.AUTO} />
 );
 
-export const EmojiVersion_0_6 = (args: Props) => (
+export const EmojiVersion_0_6 = (args: PickerProps) => (
   <Template
     {...args}
     defaultSkinTone={SkinTones.MEDIUM}
@@ -203,23 +203,23 @@ export const EmojiVersion_0_6 = (args: Props) => (
   />
 );
 
-export const EmojiVersion_1_0 = (args: Props) => (
+export const EmojiVersion_1_0 = (args: PickerProps) => (
   <Template {...args} emojiVersion="1.0" emojiStyle={EmojiStyle.NATIVE} />
 );
-export const EmojiVersion_2_0 = (args: Props) => (
+export const EmojiVersion_2_0 = (args: PickerProps) => (
   <Template {...args} emojiVersion="2.0" emojiStyle={EmojiStyle.NATIVE} />
 );
-export const EmojiVersion_3_0 = (args: Props) => (
+export const EmojiVersion_3_0 = (args: PickerProps) => (
   <Template {...args} emojiVersion="3.0" emojiStyle={EmojiStyle.NATIVE} />
 );
-export const EmojiVersion_4_0 = (args: Props) => (
+export const EmojiVersion_4_0 = (args: PickerProps) => (
   <Template {...args} emojiVersion="4.0" emojiStyle={EmojiStyle.NATIVE} />
 );
-export const EmojiVersion_5_0 = (args: Props) => (
+export const EmojiVersion_5_0 = (args: PickerProps) => (
   <Template {...args} emojiVersion="5.0" emojiStyle={EmojiStyle.NATIVE} />
 );
 
-export const CustomPreviewConfig = (args: Props) => (
+export const CustomPreviewConfig = (args: PickerProps) => (
   <Template
     {...args}
     previewConfig={{
@@ -228,7 +228,7 @@ export const CustomPreviewConfig = (args: Props) => (
     }}
   />
 );
-export const CustomCategoryConfig = (args: Props) => (
+export const CustomCategoryConfig = (args: PickerProps) => (
   <Template
     {...args}
     categories={[
@@ -285,7 +285,7 @@ export const CustomUnifiedEmojiImage = () => {
   );
 };
 
-export const HideEmojisByUnicode = (args: Props) => (
+export const HideEmojisByUnicode = (args: PickerProps) => (
   <Template {...args} emojiStyle={EmojiStyle.NATIVE} />
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10793,8 +10793,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
-"prettier-fallback@npm:prettier@^3", prettier@^3.1.1:
-  name prettier-fallback
+"prettier-fallback@npm:prettier@^3":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
   integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
@@ -10810,6 +10809,11 @@ prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^3.1.1:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
+  integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
 
 pretty-error@^4.0.0:
   version "4.0.0"
@@ -13036,15 +13040,15 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
+
 typescript@^3.7.3:
   version "3.9.10"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
-
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"


### PR DESCRIPTION
Fix #448 

This PR includes the following changes:  
- Updated the alternative union string type in the public API.  
- Marked old enums as deprecated.  
- Upgraded TypeScript version to support exporting the new public type within a single namespace.  
- Refactored some code to better align with the KISS principle.  