### PR TITLE
Fix malformed css selector

### DIFF
--- a/src/Stylesheet/stylesheet.tsx
+++ b/src/Stylesheet/stylesheet.tsx
@@ -43,7 +43,7 @@ export const commonInteractionStyles = stylesheet.create({
         ...hidden
       }
     },
-    ':has(input(:placeholder-shown))': {
+    ':has(input:placeholder-shown)': {
       visibleOnSearchOnly: hidden
     }
   },


### PR DESCRIPTION
Fixing malformed :has(input(:placeholder-shown)) to valid :has(input:placeholder-shown)