### PR TITLE
Solve race condition when switching categories

### DIFF
--- a/src/components/navigation/CategoryNavigation.tsx
+++ b/src/components/navigation/CategoryNavigation.tsx
@@ -50,8 +50,10 @@ export function CategoryNavigation() {
             allowNavigation={allowNavigation}
             categoryConfig={categoryConfig}
             onClick={() => {
-              setActiveCategory(category);
               scrollCategoryIntoView(category);
+              setTimeout(() => {
+                setActiveCategory(category);
+              }, 10);
             }}
           />
         );


### PR DESCRIPTION
## What changed?

- Add a 10ms delay after calling `scrollCategoryIntoView(...)`
    - Gives time for the element to scroll into view, preventing the value set in `setActiveCategory(...)` from being overwritten by the `useScrollCategoryIntoView` hook.

Resolves: #446
Resolves: #414
Potentially resolves: #449

## How was this tested?

- By spam clicking between categories making sure that each click brought me to the correct category and selected the correct icon.

| Before | After |
| :-: | :-: |
| <video src="https://github.com/user-attachments/assets/2d62f01b-4817-474b-b889-c7ef73cad855" /> | <video src="https://github.com/user-attachments/assets/8d8ea139-808e-4b90-869d-35fd30cee42e" /> |

>[!note]
>Ignore the fact that categories are on the side, these videos were recorded using a forked version I'm working on.

## Additional notes

- I know if the interval is 0, it won't fix the issue
- 10ms works, 50ms definitely works
    - I haven't tried anything lower than 10ms