### PR TITLE
Allow Categories[] type for categories prop

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -7,6 +7,7 @@ import {
   emojiUrlByUnified,
 } from '../dataUtils/emojiSelectors';
 import {
+  Categories,
   EmojiClickData,
   EmojiStyle,
   SkinTonePickerLocation,
@@ -107,7 +108,7 @@ export type PickerConfigInternal = {
   skinTonesDisabled: boolean;
   autoFocusSearch: boolean;
   emojiStyle: EmojiStyle;
-  categories: CategoriesConfig;
+  categories: CategoriesConfig | Categories[];
   theme: Theme;
   suggestedEmojisMode: SuggestionMode;
   lazyLoadEmojis: boolean;


### PR DESCRIPTION
The docs say "To only sort/omit categories, you can simply pass an array of category names to display" but this is not allowed by the current typing.  This should fix it.  