### PR TITLE
Test flairup 1.1.1-rc.0 RC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.19.4",
       "license": "MIT",
       "dependencies": {
-        "flairup": "1.0.0"
+        "flairup": "1.1.1-rc.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.10",
@@ -11227,9 +11227,9 @@
       }
     },
     "node_modules/flairup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.0.0.tgz",
-      "integrity": "sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==",
+      "version": "1.1.1-rc.0",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.1.1-rc.0.tgz",
+      "integrity": "sha512-x1dQ0gQTZ2xUcjGwekp+ezCQI3UKuX6CXh7ovj9eXuraE8rMMN5JAajt9Gf9GHtUhQ47n0Zp4jQL6OwMykWmjg==",
       "license": "MIT"
     },
     "node_modules/flat-cache": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,6 @@
     "vitest": "^2.0.5"
   },
   "dependencies": {
-    "flairup": "1.0.0"
+    "flairup": "1.1.1-rc.0"
   }
 }

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -27,7 +27,12 @@ const styles = stylesheet.create({
     '.': 'epr-btn',
     cursor: 'pointer',
     border: '0',
-    background: 'none',
+    // Longhand, not `background: 'none'`: a shorthand reset shares its
+    // conflict keys with every background longhand, so cx() would drop
+    // this whole class wherever a later class sets background-image
+    // (e.g. the category nav sprite) and the native button face would
+    // show through.
+    backgroundColor: 'transparent',
     outline: 'none',
   },
 });

--- a/src/components/emoji/NativeEmoji.tsx
+++ b/src/components/emoji/NativeEmoji.tsx
@@ -18,9 +18,12 @@ export function NativeEmoji({
   return (
     <span
       className={cx(
-        styles.nativeEmoji,
-        emojiStyles.common,
+        // Order matters: cx() lets the later class win same-property
+        // conflicts, so the zeroing reset must come first and the real
+        // font-size last — otherwise the emoji renders at 0px.
         emojiStyles.external,
+        emojiStyles.common,
+        styles.nativeEmoji,
         className,
       )}
       data-unified={unified}

--- a/test/components/CategoryButton.test.tsx
+++ b/test/components/CategoryButton.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { stylesheet } from '../../src/Stylesheet/stylesheet';
 import { CategoryButton } from '../../src/components/navigation/CategoryButton';
 import { Categories, CategoryConfig } from '../../src/types/exposedTypes';
 
@@ -88,6 +89,24 @@ describe('CategoryButton', () => {
     expect(screen.getByTestId('config-icon')).toBeDefined();
     // Custom icon from prop should NOT be rendered
     expect(screen.queryByTestId('custom-icon')).toBeNull();
+  });
+
+  it('keeps a transparent background behind the sprite icon', () => {
+    // The suite renders components without the picker's <PickerStyleTag>,
+    // so mount the emitted CSS the same way the app does.
+    render(
+      <>
+        <style>{stylesheet.getStyle()}</style>
+        <CategoryButton {...defaultProps} />
+      </>,
+    );
+    const button = screen.getByRole('tab', { name: 'Smileys & People' });
+    // The Button reset composes with the sprite background-image across
+    // two cx() classes: the transparent background must survive so no
+    // native button face shows behind the icon.
+    expect(getComputedStyle(button).backgroundColor).toBe(
+      'rgba(0, 0, 0, 0)',
+    );
   });
 
   it('applies active class when isActiveCategory is true', () => {

--- a/test/components/NativeEmoji.test.tsx
+++ b/test/components/NativeEmoji.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { stylesheet } from '../../src/Stylesheet/stylesheet';
+import { NativeEmoji } from '../../src/components/emoji/NativeEmoji';
+
+describe('NativeEmoji', () => {
+  it('renders at the configured emoji size, not the zeroing reset', () => {
+    // The suite renders components without the picker's <PickerStyleTag>,
+    // so mount the emitted CSS the same way the app does.
+    render(
+      <>
+        <style>{stylesheet.getStyle()}</style>
+        <NativeEmoji unified="1f600" style={{}} />
+      </>,
+    );
+    const emoji = screen.getByText('😀');
+    // emojiStyles.external zeroes the font-size for image containers; the
+    // real size must win the cx() composition or native emoji are invisible.
+    expect(getComputedStyle(emoji).fontSize).toBe('var(--epr-emoji-size)');
+  });
+});


### PR DESCRIPTION
Trial upgrade to flairup@1.1.1-rc.0 (exact pin) to check for regressions.

Visual inspection against production found two incompatibilities with the RC's cx() conflict contract, both fixed on this branch:

1. Grey boxes behind nav icons — Button's `background: none` reset shared conflict keys with the category sprite's `background-image`, so cx() dropped the reset and the native button face showed through. Fixed with `backgroundColor: transparent` + computed-style regression test.
2. Invisible native emoji (empty reactions pill and body) — `emojiStyles.external` (`font-size: 0`) was composed after the real size and won the conflict. Reordered reset-first + regression test.

Signals on this branch:
- type-check (tsc --noEmit): pass
- tests (vitest run): 53/53 pass
- build (tsdx): pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed button styling so transparent backgrounds remain intact when sprite icons or other background images are applied.
  * Fixed native emojis displaying at the correct configured size.
  * Added coverage to verify transparent button backgrounds and native emoji sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->