### PR TITLE
Test flairup 1.1.1 final

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.19.4",
       "license": "MIT",
       "dependencies": {
-        "flairup": "1.0.0"
+        "flairup": "1.1.1-rc.1"
       },
       "devDependencies": {
         "@babel/core": "^7.18.10",
@@ -11227,10 +11227,13 @@
       }
     },
     "node_modules/flairup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.0.0.tgz",
-      "integrity": "sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==",
-      "license": "MIT"
+      "version": "1.1.1-rc.1",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.1.1-rc.1.tgz",
+      "integrity": "sha512-ae8tNwOGxf3jMPVZsupGYtFnr7aEv+Clb+Ky5jJKUXLRk65FVWUI99f9qGiJ27sASV08+OhGbAwcB7R+XQCUDw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
     "node_modules/flat-cache": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emoji-picker-react",
-  "version": "4.19.4",
+  "version": "4.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emoji-picker-react",
-      "version": "4.19.4",
+      "version": "4.20.0",
       "license": "MIT",
       "dependencies": {
         "flairup": "1.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.19.4",
       "license": "MIT",
       "dependencies": {
-        "flairup": "1.1.1-rc.1"
+        "flairup": "1.1.1"
       },
       "devDependencies": {
         "@babel/core": "^7.18.10",
@@ -11227,9 +11227,9 @@
       }
     },
     "node_modules/flairup": {
-      "version": "1.1.1-rc.1",
-      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.1.1-rc.1.tgz",
-      "integrity": "sha512-ae8tNwOGxf3jMPVZsupGYtFnr7aEv+Clb+Ky5jJKUXLRk65FVWUI99f9qGiJ27sASV08+OhGbAwcB7R+XQCUDw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.1.1.tgz",
+      "integrity": "sha512-NRdjAYpQLEOmvLebVCfL2D88M6CZOz3LCK06arH1HKSHbrJgEDbqzgJjur2yuRtbb1YAtElacR57tf5GBAHaqg==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || >=22.12.0"

--- a/package.json
+++ b/package.json
@@ -116,6 +116,6 @@
     "vitest": "^2.0.5"
   },
   "dependencies": {
-    "flairup": "1.1.1-rc.1"
+    "flairup": "1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -116,6 +116,6 @@
     "vitest": "^2.0.5"
   },
   "dependencies": {
-    "flairup": "1.0.0"
+    "flairup": "1.1.1-rc.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.19.4",
+  "version": "4.20.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -27,7 +27,12 @@ const styles = stylesheet.create({
     '.': 'epr-btn',
     cursor: 'pointer',
     border: '0',
-    background: 'none',
+    // Longhand, not `background: 'none'`: a shorthand reset shares its
+    // conflict keys with every background longhand, so cx() would drop
+    // this whole class wherever a later class sets background-image
+    // (e.g. the category nav sprite) and the native button face would
+    // show through.
+    backgroundColor: 'transparent',
     outline: 'none',
   },
 });

--- a/src/components/emoji/NativeEmoji.tsx
+++ b/src/components/emoji/NativeEmoji.tsx
@@ -18,9 +18,12 @@ export function NativeEmoji({
   return (
     <span
       className={cx(
-        styles.nativeEmoji,
-        emojiStyles.common,
+        // Order matters: cx() lets the later class win same-property
+        // conflicts, so the zeroing reset must come first and the real
+        // font-size last — otherwise the emoji renders at 0px.
         emojiStyles.external,
+        emojiStyles.common,
+        styles.nativeEmoji,
         className,
       )}
       data-unified={unified}

--- a/test/components/CategoryButton.test.tsx
+++ b/test/components/CategoryButton.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { stylesheet } from '../../src/Stylesheet/stylesheet';
 import { CategoryButton } from '../../src/components/navigation/CategoryButton';
 import { Categories, CategoryConfig } from '../../src/types/exposedTypes';
 
@@ -88,6 +89,24 @@ describe('CategoryButton', () => {
     expect(screen.getByTestId('config-icon')).toBeDefined();
     // Custom icon from prop should NOT be rendered
     expect(screen.queryByTestId('custom-icon')).toBeNull();
+  });
+
+  it('keeps a transparent background behind the sprite icon', () => {
+    // The suite renders components without the picker's <PickerStyleTag>,
+    // so mount the emitted CSS the same way the app does.
+    render(
+      <>
+        <style>{stylesheet.getStyle()}</style>
+        <CategoryButton {...defaultProps} />
+      </>,
+    );
+    const button = screen.getByRole('tab', { name: 'Smileys & People' });
+    // The Button reset composes with the sprite background-image across
+    // two cx() classes: the transparent background must survive so no
+    // native button face shows behind the icon.
+    expect(getComputedStyle(button).backgroundColor).toBe(
+      'rgba(0, 0, 0, 0)',
+    );
   });
 
   it('applies active class when isActiveCategory is true', () => {

--- a/test/components/NativeEmoji.test.tsx
+++ b/test/components/NativeEmoji.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { stylesheet } from '../../src/Stylesheet/stylesheet';
+import { NativeEmoji } from '../../src/components/emoji/NativeEmoji';
+
+describe('NativeEmoji', () => {
+  it('renders at the configured emoji size, not the zeroing reset', () => {
+    // The suite renders components without the picker's <PickerStyleTag>,
+    // so mount the emitted CSS the same way the app does.
+    render(
+      <>
+        <style>{stylesheet.getStyle()}</style>
+        <NativeEmoji unified="1f600" style={{}} />
+      </>,
+    );
+    const emoji = screen.getByText('😀');
+    // emojiStyles.external zeroes the font-size for image containers; the
+    // real size must win the cx() composition or native emoji are invisible.
+    expect(getComputedStyle(emoji).fontSize).toBe('var(--epr-emoji-size)');
+  });
+});


### PR DESCRIPTION
Trial upgrade to flairup@1.1.1 final (exact pin) to check for regressions.

Same branch shape as #514 (pin commit, promoted from the 1.1.1-rc.1 trial, + the two cx-contract adaptations cherry-picked from the rc.0 trial). No new incompatibilities found with the final: the Rule.key pre/postcondition split and unified sheet-cache scope required no consumer changes.

Signals on this branch:
- type-check (tsc --noEmit): pass
- tests (vitest run): 53/53 pass
- build (tsdx): pass

Supersedes #514 for flairup 1.1.1 validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed button styling so transparent backgrounds remain intact when additional background imagery is applied.
  - Corrected native emoji sizing to consistently use the picker’s configured emoji size.
  - Improved styling consistency for category buttons and native emoji rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->