### PR TITLE
Use ShipStyles instead of FlairUp

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See [PROPS.md](PROPS.md) for the complete props reference.
 
 ## Styling
 
-No stylesheet import needed. All styles are scoped via [Flairup](https://github.com/ealush/flairup) — generated class names are hashed, so the picker's CSS won't leak into or clash with your app's styles.
+No stylesheet import needed. All styles are scoped via [ShipStyles](https://github.com/ealush/shipstyles) — generated class names are hashed, so the picker's CSS won't leak into or clash with your app's styles.
 
 Restyle the picker by overriding [CSS variables](CSS_VARIABLES.md) on `.EmojiPickerReact`:
 

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@ See [PROPS.md](PROPS.md) for the complete props reference.
 
 ## Styling
 
-No stylesheet import needed. All styles are scoped via [Flairup](https://github.com/ealush/flairup) — generated class names are hashed, so the picker's CSS won't leak into or clash with your app's styles.
+No stylesheet import needed. All styles are scoped via [ShipStyles](https://github.com/ealush/shipstyles) — generated class names are hashed, so the picker's CSS won't leak into or clash with your app's styles.
 
 Restyle the picker by overriding [CSS variables](CSS_VARIABLES.md) on `.EmojiPickerReact`:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.20.3",
       "license": "MIT",
       "dependencies": {
-        "flairup": "1.1.2"
+        "shipstyles": "1.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.10",
@@ -11226,12 +11226,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/flairup": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.1.2.tgz",
-      "integrity": "sha512-AiTgxMXuGu5YpEe+39c61pe+0dhmzGMQkntbJjK9FdUY/UmtqlhIVGtrBR2zznbShArdjKWyYNV3mGBJC7fTWQ==",
-      "license": "MIT"
-    },
     "node_modules/flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -18501,6 +18495,12 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/shipstyles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shipstyles/-/shipstyles-1.0.0.tgz",
+      "integrity": "sha512-1AcihfXo/mSxqeOdoKqq/5TNv+vSH0dBYPFq88PUX5FBkK5pRmY5TP9SuMNio85PQ+euUI67+KpSVk1cUVDCgA==",
+      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,6 @@
     "vitest": "^2.0.5"
   },
   "dependencies": {
-    "flairup": "1.1.2"
+    "shipstyles": "1.0.0"
   }
 }

--- a/src/Stylesheet/stylesheet.tsx
+++ b/src/Stylesheet/stylesheet.tsx
@@ -1,5 +1,5 @@
-import { Styles, createSheet } from 'flairup';
 import * as React from 'react';
+import { Styles, createSheet } from 'shipstyles';
 
 import { ClassNames } from '../DomUtils/classNames';
 

--- a/src/components/Layout/Flex.tsx
+++ b/src/components/Layout/Flex.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { stylesheet } from '../../Stylesheet/stylesheet';
 

--- a/src/components/Layout/Space.tsx
+++ b/src/components/Layout/Space.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 type Props = Readonly<{
   className?: string;

--- a/src/components/Reactions/BtnPlus.tsx
+++ b/src/components/Reactions/BtnPlus.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { darkMode, stylesheet } from '../../Stylesheet/stylesheet';
 import { Button } from '../atoms/Button';

--- a/src/components/Reactions/Reactions.tsx
+++ b/src/components/Reactions/Reactions.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { commonStyles, stylesheet } from '../../Stylesheet/stylesheet';
 import {

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { stylesheet } from '../../Stylesheet/stylesheet';
 

--- a/src/components/body/Body.tsx
+++ b/src/components/body/Body.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { ClassNames } from '../../DomUtils/classNames';
 import {

--- a/src/components/body/EmojiCategory.tsx
+++ b/src/components/body/EmojiCategory.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { ClassNames } from '../../DomUtils/classNames';
 import {

--- a/src/components/body/EmojiList.tsx
+++ b/src/components/body/EmojiList.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { ClassNames } from '../../DomUtils/classNames';
 import { getLabelHeight } from '../../DomUtils/elementPositionInRow';

--- a/src/components/body/EmojiVariationPicker.tsx
+++ b/src/components/body/EmojiVariationPicker.tsx
@@ -1,6 +1,6 @@
-import { cx } from 'flairup';
 import * as React from 'react';
 import { useEffect } from 'react';
+import { cx } from 'shipstyles';
 
 import { ClassNames } from '../../DomUtils/classNames';
 import { focusFirstVisibleEmoji } from '../../DomUtils/keyboardNavigation';

--- a/src/components/emoji/ClickableEmojiButton.tsx
+++ b/src/components/emoji/ClickableEmojiButton.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { ClassNames } from '../../DomUtils/classNames';
 import {

--- a/src/components/emoji/EmojiImg.tsx
+++ b/src/components/emoji/EmojiImg.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { stylesheet } from '../../Stylesheet/stylesheet';
 import { EmojiStyle } from '../../types/exposedTypes';

--- a/src/components/emoji/NativeEmoji.tsx
+++ b/src/components/emoji/NativeEmoji.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { stylesheet } from '../../Stylesheet/stylesheet';
 import { parseNativeEmoji } from '../../dataUtils/parseNativeEmoji';

--- a/src/components/footer/Preview.tsx
+++ b/src/components/footer/Preview.tsx
@@ -1,6 +1,6 @@
-import { cx } from 'flairup';
 import * as React from 'react';
 import { useState } from 'react';
+import { cx } from 'shipstyles';
 
 import {
   commonInteractionStyles,

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { commonInteractionStyles } from '../../Stylesheet/stylesheet';
 import Relative from '../Layout/Relative';

--- a/src/components/header/Search/BtnClearSearch.tsx
+++ b/src/components/header/Search/BtnClearSearch.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import {
   commonInteractionStyles,

--- a/src/components/header/Search/IcnSearch.tsx
+++ b/src/components/header/Search/IcnSearch.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { darkMode, stylesheet } from '../../../Stylesheet/stylesheet';
 

--- a/src/components/header/Search/Search.tsx
+++ b/src/components/header/Search/Search.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { darkMode, stylesheet } from '../../../Stylesheet/stylesheet';
 import {

--- a/src/components/header/SkinTonePicker/BtnSkinToneVariation.tsx
+++ b/src/components/header/SkinTonePicker/BtnSkinToneVariation.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { stylesheet } from '../../../Stylesheet/stylesheet';
 import { skinTonesNamed } from '../../../data/skinToneVariations';

--- a/src/components/header/SkinTonePicker/SkinTonePicker.tsx
+++ b/src/components/header/SkinTonePicker/SkinTonePicker.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { ClassNames } from '../../../DomUtils/classNames';
 import { stylesheet } from '../../../Stylesheet/stylesheet';

--- a/src/components/main/PickerMain.tsx
+++ b/src/components/main/PickerMain.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { ClassNames } from '../../DomUtils/classNames';
 import { stylesheet } from '../../Stylesheet/stylesheet';

--- a/src/components/navigation/CategoryButton.tsx
+++ b/src/components/navigation/CategoryButton.tsx
@@ -1,5 +1,5 @@
-import { cx } from 'flairup';
 import * as React from 'react';
+import { cx } from 'shipstyles';
 
 import { ClassNames } from '../../DomUtils/classNames';
 import {

--- a/src/components/navigation/CategoryNavigation.tsx
+++ b/src/components/navigation/CategoryNavigation.tsx
@@ -1,6 +1,6 @@
-import { cx } from 'flairup';
 import * as React from 'react';
 import { useState } from 'react';
+import { cx } from 'shipstyles';
 
 import { stylesheet } from '../../Stylesheet/stylesheet';
 import { categoryFromCategoryConfig } from '../../config/categoryConfig';

--- a/website/README.md
+++ b/website/README.md
@@ -10,6 +10,6 @@ npm run dev
 ```
 
 The site consumes the **published** `emoji-picker-react` tarball (same
-dogfood pattern as FlairUp's website). The deploy workflow refreshes it to
+dogfood pattern as ShipStyles's website). The deploy workflow refreshes it to
 `latest` at build time when stale, so no version-bump commits are needed —
 `website/package-lock.json` only pins the rest of the tree.


### PR DESCRIPTION
# Use ShipStyles instead of FlairUp

FlairUp was renamed to [ShipStyles](https://github.com/ealush/shipstyles).
This migrates the picker's sole runtime dependency to the canonical package.
No behavior change.

## Dependency diff

```diff
 "dependencies": {
-  "flairup": "1.1.2"
+  "shipstyles": "1.0.0"
 }
 ```

Lockfile: `node_modules/flairup` (registry `flairup-1.1.2.tgz`) replaced by
`node_modules/shipstyles` (registry `shipstyles-1.0.0.tgz`), 7 lines
changed. Zero `flairup` references remain in the root lockfile or tree
(`npm ls flairup` → empty; `npm ls --omit=dev` → only `shipstyles@1.0.0`).
The picker does not ship both packages.

## Code and docs

- 23 source files: `from 'flairup'` → `from 'shipstyles'` (the imported
  `Styles` type is unchanged in the new package). Three files also had
  their `react` import moved above the `shipstyles` import to satisfy the
  existing `import/order` rule.
- `README.md`: styling credit now links ShipStyles. `website/README.md`:
  dogfood note updated. Regenerated `llms.txt` included.
- The 🎩 in `RandomEmoji.tsx` is a party emoji in the picker's emoji list,
  not branding — left alone.

## Verification

- `npm run type-check`: clean.
- `npm run lint`: 0 errors, 28 warnings — exactly the pre-change baseline
  (was 51 mid-migration before import reordering; fixed, not suppressed).
- `npx vitest run`: 75/75 pass, same as baseline.
- Style-output equivalence: full SSR `renderToString` CSS (25,202 bytes)
  **byte-identical** before/after (same sha256), and the rendered HTML
  byte-identical too. Expected: identical runtime, unchanged `'epr'` sheet
  name and creation order.
- `npm run build`: passes (data, tsdx, docs).

## Not in this PR

No release, no version bump, no website lockfile churn (`website/` consumes
the published tarball and refreshes on deploy). Merge + release separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated styling documentation and website references to identify ShipStyles as the CSS scoping library.

* **Refactor**
  * Switched the application’s styling utilities from Flairup to ShipStyles.
  * Preserved existing component behavior while maintaining scoped, hashed styles to help prevent conflicts with host application styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->