### PR TITLE
chore: fix website deployment under subpath

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
         with:
-          # Automatically inject basePath and disable server image optimization.
+          # NOTE: this does not inject basePath; the subpath prefix lives in
+          # website/next.config.js and is verified by "Verify subpath asset
+          # URLs" below.
           static_site_generator: next
       - name: Restore cache
         uses: actions/cache@v4
@@ -76,6 +78,13 @@ jobs:
       - name: Static HTML export with Next.js
         if: github.event_name != 'schedule' || steps.refresh.outputs.stale == 'true'
         run: npx --no-install next export
+      - name: Verify subpath asset URLs
+        if: github.event_name != 'schedule' || steps.refresh.outputs.stale == 'true'
+        run: |
+          if grep -rhoE '(src|href)="/_next/[^"]*"' out/ | head -1; then
+            echo "Root-absolute asset URLs found; the export is missing its basePath." >&2
+            exit 1
+          fi
       - name: Upload artifact
         if: github.event_name != 'schedule' || steps.refresh.outputs.stale == 'true'
         uses: actions/upload-pages-artifact@v3

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // The export is served from a subpath (ealush.com/emoji-picker-react via
+  // GitHub Pages project site), so every asset URL must carry the prefix.
+  // actions/configure-pages does NOT inject this; it lives here.
+  basePath: '/emoji-picker-react',
 }
 
 module.exports = nextConfig

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,8 +8,7 @@
       "name": "emoji-picker-react",
       "version": "0.1.1",
       "dependencies": {
-        "@vercel/analytics": "^1.1.1",
-        "emoji-picker-react": "4.20.0",
+        "emoji-picker-react": "^4.20.4",
         "next": "13.5.6",
         "react": "^18",
         "react-dom": "^18"
@@ -510,14 +509,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.1.3.tgz",
-      "integrity": "sha512-Z0l0y8TnUnnxr+on7oIMB9qQOoSJIniYMzUng6+NU8VVDkZ+kt2QGD5hzODwsuiRJAsjW528iUEtbWCEGkSCCg==",
-      "dependencies": {
-        "server-only": "^0.0.1"
-      }
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -1038,18 +1029,18 @@
       }
     },
     "node_modules/emoji-picker-react": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.20.0.tgz",
-      "integrity": "sha512-r8R+OrkG+XSHKo6M8iCNnfObCnbmYuxy3ZYbWmN38+1CpjbZWzjWcACMdFT3IHDkTZZxTVsyHMHVXUnTBvJNvg==",
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.20.4.tgz",
+      "integrity": "sha512-tK32hJTKga0m0Zzaq5aejlr8OlTZVNDNoXZ3EEd4hIFX6EdJPysjnTW8yg1ESBa5yFVk2nRw5BKwUoAgijR7uw==",
       "license": "MIT",
       "dependencies": {
-        "flairup": "1.1.1"
+        "shipstyles": "1.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": ">=16"
+        "react": ">=16.8"
       }
     },
     "node_modules/emoji-regex": {
@@ -1716,15 +1707,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/flairup": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.1.1.tgz",
-      "integrity": "sha512-NRdjAYpQLEOmvLebVCfL2D88M6CZOz3LCK06arH1HKSHbrJgEDbqzgJjur2yuRtbb1YAtElacR57tf5GBAHaqg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/flat-cache": {
@@ -3241,11 +3223,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/server-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
-      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
-    },
     "node_modules/set-function-length": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
@@ -3297,6 +3274,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shipstyles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shipstyles/-/shipstyles-1.0.0.tgz",
+      "integrity": "sha512-1AcihfXo/mSxqeOdoKqq/5TNv+vSH0dBYPFq88PUX5FBkK5pRmY5TP9SuMNio85PQ+euUI67+KpSVk1cUVDCgA==",
+      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.0.5",

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@vercel/analytics": "^1.1.1",
-    "emoji-picker-react": "4.20.0",
+    "emoji-picker-react": "^4.20.4",
     "next": "13.5.6",
     "react": "^18",
     "react-dom": "^18"

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import Head from "next/head";
 import { Inter, Fraunces } from "next/font/google";
 import styles from "@/styles/Home.module.css";
-import { Analytics } from "@vercel/analytics/react";
 import Link from "next/link";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
@@ -45,7 +44,7 @@ export default function Home({ initialStats }: HomeProps) {
           content="A lightweight, customizable emoji picker component for React applications. TypeScript support, multiple themes, skin tones, and 1800+ emojis."
         />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href="./favicon.ico" />
         <meta property="og:title" content="emoji-picker-react" />
         <meta
           property="og:description"
@@ -116,8 +115,6 @@ export default function Home({ initialStats }: HomeProps) {
 
         <Footer />
       </main>
-
-      <Analytics />
     </>
   );
 }


### PR DESCRIPTION
The live site rendered raw unstyled HTML with ~80 failed asset requests and dead pickers.

Root cause: the Next.js export had no basePath, so every asset URL was root-absolute (/_next/...) while GitHub Pages serves this repo under ealush.com/emoji-picker-react/. Broken since the website/ move in #517; the workflow comment claiming configure-pages injects basePath was wrong.

Changes:
- website/next.config.js: basePath '/emoji-picker-react'.
- website favicon: relative URL (raw /favicon.ico 404d under the subpath; Next Link already prefixes automatically).
- Removed @vercel/analytics (injected /_vercel/insights/script.js, which 404s on Pages; GA remains).
- website picker dep 4.20.0 -> ^4.20.4 (flairup transitive gone, shipstyles in).
- website.yml: corrected the comment + added a fail-closed grep guard rejecting root-absolute /_next URLs in out/.

Verified: local export served under /emoji-picker-react/ loads with 0 failed requests (was 80), both pickers render, emoji clicks fill the output, version badge reads live (was stuck v-dash). Deliberately chore:-titled so merge does not cut a picker release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset and favicon paths for reliable loading when the website is hosted under a project subpath.
  * Added a build check to detect incorrectly rooted asset URLs.

* **Updates**
  * Updated the emoji picker package to version 4.20.4.
  * Removed website analytics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->