### PR TITLE
chore: increase website emoji rain density by 30%

### DIFF
--- a/website/src/components/FloatingEmojis.tsx
+++ b/website/src/components/FloatingEmojis.tsx
@@ -36,8 +36,12 @@ export function FloatingEmojis() {
   const curOffsetsRef = useRef<Map<number, { x: number; y: number }>>(new Map());
 
   useEffect(() => {
-    const count = 29; // +30% rain density
-    const picked = shuffle(allEmojis).slice(0, count);
+    const count = 35;
+    const shuffled = shuffle(allEmojis);
+    const picked = Array.from(
+      { length: count },
+      (_, i) => shuffled[i % shuffled.length],
+    );
     setDrops(
       picked.map((emoji, i) => ({
         id: i,
@@ -86,7 +90,9 @@ export function FloatingEmojis() {
 
       dropsEls.forEach((el) => {
         const id = Number(el.dataset.id);
-        const rect = el.getBoundingClientRect();
+        const animated =
+          el.querySelector<HTMLSpanElement>(`.${styles.rainEmoji}`) ?? el;
+        const rect = animated.getBoundingClientRect();
         const cx = rect.left + rect.width / 2;
         const cy = rect.top + rect.height / 2;
 
@@ -140,7 +146,7 @@ export function FloatingEmojis() {
   if (reduced) {
     return (
       <div ref={containerRef} className={styles.rainContainer} aria-hidden>
-        {drops.slice(0, 13).map((d) => (
+        {drops.slice(0, 16).map((d) => (
           <span key={d.id} className={styles.rainDrop} style={{ left: `${d.x}%`, fontSize: `${d.size}rem`, opacity: 0.18 }}>
             {d.emoji}
           </span>

--- a/website/src/components/FloatingEmojis.tsx
+++ b/website/src/components/FloatingEmojis.tsx
@@ -36,7 +36,7 @@ export function FloatingEmojis() {
   const curOffsetsRef = useRef<Map<number, { x: number; y: number }>>(new Map());
 
   useEffect(() => {
-    const count = 22;
+    const count = 29; // +30% rain density
     const picked = shuffle(allEmojis).slice(0, count);
     setDrops(
       picked.map((emoji, i) => ({
@@ -140,7 +140,7 @@ export function FloatingEmojis() {
   if (reduced) {
     return (
       <div ref={containerRef} className={styles.rainContainer} aria-hidden>
-        {drops.slice(0, 10).map((d) => (
+        {drops.slice(0, 13).map((d) => (
           <span key={d.id} className={styles.rainDrop} style={{ left: `${d.x}%`, fontSize: `${d.size}rem`, opacity: 0.18 }}>
             {d.emoji}
           </span>


### PR DESCRIPTION
Rain count 22 -> 29 (reduced-motion static set 10 -> 13 to match). Chore-titled so merge does not cut a picker release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Increased the number of animated rain drops for a denser visual effect.
  * Emoji visuals now repeat as needed across the full rain effect.
  * Improved mouse-follow behavior for more accurate emoji movement.
  * Added more static emoji drops when reduced-motion settings are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->