### PR TITLE
fix: keep translated emojiData after space bar preview

### DIFF
--- a/src/hooks/useSetVariationPicker.ts
+++ b/src/hooks/useSetVariationPicker.ts
@@ -1,13 +1,28 @@
-import { emojiFromElement, NullableElement } from '../DomUtils/selectors';
+import {
+  allUnifiedFromEmojiElement,
+  NullableElement,
+} from '../DomUtils/selectors';
 import { useSetAnchoredEmojiRef } from '../components/context/ElementRefContext';
 import { useEmojiVariationPickerState } from '../components/context/PickerContext';
+import { usePickerDataContext } from '../components/context/PickerDataContext';
 
 export default function useSetVariationPicker() {
   const setAnchoredEmojiRef = useSetAnchoredEmojiRef();
   const [, setEmojiVariationPicker] = useEmojiVariationPickerState();
+  // Context-aware lookup: respects the `emojiData` prop (e.g. translations).
+  // The legacy global lookup only knows the default English dataset.
+  // https://github.com/ealush/emoji-picker-react/issues/503
+  const { emojiByUnified } = usePickerDataContext();
 
   return function setVariationPicker(element: NullableElement) {
-    const [emoji] = emojiFromElement(element);
+    const { unified, originalUnified } = allUnifiedFromEmojiElement(element);
+    const resolvedUnified = unified ?? originalUnified;
+
+    if (!resolvedUnified) {
+      return;
+    }
+
+    const emoji = emojiByUnified(resolvedUnified);
 
     if (emoji) {
       setAnchoredEmojiRef(element);

--- a/test/issue-503-preview-translation.test.tsx
+++ b/test/issue-503-preview-translation.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import EmojiPicker, { EmojiStyle } from '../src';
+import { Categories } from '../src/config/categoryConfig';
+import { EmojiData } from '../src/types/exposedTypes';
+
+vi.mock('../src/hooks/preloadEmoji', () => ({
+  preloadEmojiIfNeeded: () => undefined,
+  preloadEmoji: () => undefined,
+  preloadedEmojs: new Set(),
+}));
+
+// Translated dataset: 1f600 is "cara sonriente", NOT the default
+// English "grinning face".
+// https://github.com/ealush/emoji-picker-react/issues/503
+const translatedEmojiData: EmojiData = {
+  categories: {
+    [Categories.SMILEYS_PEOPLE]: {
+      category: Categories.SMILEYS_PEOPLE,
+      name: 'Smileys & People',
+    },
+    [Categories.SUGGESTED]: {
+      category: Categories.SUGGESTED,
+      name: 'Frequently Used',
+    },
+    [Categories.CUSTOM]: {
+      category: Categories.CUSTOM,
+      name: 'Custom Emojis',
+    },
+  },
+  emojis: {
+    [Categories.SUGGESTED]: [],
+    [Categories.CUSTOM]: [],
+    [Categories.SMILEYS_PEOPLE]: [
+      { n: ['cara', 'cara sonriente'], u: '1f600', a: '1' },
+      { n: ['gato'], u: '1f431', a: '0.6' },
+      // Must exist: the preview falls back to this emoji when idle.
+      { n: ['cara sonriente con ojos sonrientes'], u: '1f60a', a: '0.6' },
+    ],
+  },
+};
+
+describe('issue #503: space bar must not lose translated emojiData', () => {
+  it('keeps the translated preview caption after space + blur', async () => {
+    render(
+      <EmojiPicker
+        emojiData={translatedEmojiData}
+        emojiStyle={EmojiStyle.NATIVE}
+      />,
+    );
+
+    const button = await screen.findByLabelText('cara sonriente');
+
+    // Focusing shows the translated name in the preview.
+    button.focus();
+    await screen.findByText('cara sonriente');
+
+    // Space opens the variation picker for the focused emoji...
+    fireEvent.keyDown(button, { key: ' ' });
+
+    // ...then focus leaves (e.g. hovering blank space), so the preview
+    // falls back to the variation-picker emoji caption.
+    fireEvent.blur(button);
+
+    // The caption must still come from the translated dataset,
+    // not the default English one.
+    await screen.findByText('cara sonriente');
+    expect(screen.queryByText('grinning face')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #503.

Space bar resolves the variation-picker emoji through the legacy global lookup, which only knows the default English dataset — the preview then falls back to English names. Resolve via the context-aware lookup instead, mirroring the existing mouse path (`emojiFromEvent`).

Repro test included: translated dataset shows English caption after space+blur before the fix, translated after.