### PR TITLE
docs: use npm commands in contributing guide (#372)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Before you get started, make sure you have the following requirements in place:
 3. Install all the necessary dependencies using:
 
    ```bash
-   yarn install
+   npm install
    ```
 
 #### Write & Test Changes to the Code
@@ -141,7 +141,7 @@ Before you get started, make sure you have the following requirements in place:
 1. In the repository root, run the following command:
 
    ```bash
-   yarn run storybook
+   npm run storybook
    ```
 
 2. If all the installation process is succeed, you should be able to see the Storybook webpage on [localhost:6006](http://localhost:6006/).


### PR DESCRIPTION
The repo migrated from yarn to npm (`yarn.lock` removed, `package-lock.json` in place, CI and scripts all use `npm`), but CONTRIBUTING.md still showed `yarn install` / `yarn run storybook`.\n\nUpdated both commands to npm. Note this inverts the original 2023 report (which asked for yarn over npm) — npm is now the repo standard.\n\nCloses #372.