### PR TITLE
fix: hide category navigation when only one category is visible (#396)

### DIFF
--- a/src/components/navigation/CategoryNavigation.tsx
+++ b/src/components/navigation/CategoryNavigation.tsx
@@ -31,6 +31,17 @@ export function CategoryNavigation() {
   const CategoryNavigationRef = useCategoryNavigationRef();
   const hideCustomCategory = useShouldHideCustomEmojis();
 
+  const visibleCategories = categoriesConfig.filter(
+    categoryConfig =>
+      !(isCustomCategory(categoryConfig) && hideCustomCategory),
+  );
+
+  // A single tab navigates nowhere — hide the bar to reclaim its space.
+  // https://github.com/ealush/emoji-picker-react/issues/396
+  if (visibleCategories.length <= 1) {
+    return null;
+  }
+
   return (
     <div
       className={cx(styles.nav)}
@@ -39,13 +50,9 @@ export function CategoryNavigation() {
       id="epr-category-nav-id"
       ref={CategoryNavigationRef}
     >
-      {categoriesConfig.map((categoryConfig) => {
+      {visibleCategories.map(categoryConfig => {
         const category = categoryFromCategoryConfig(categoryConfig);
         const isActiveCategory = category === activeCategory;
-
-        if (isCustomCategory(categoryConfig) && hideCustomCategory) {
-          return null;
-        }
 
         const allowNavigation = !isSearchMode && !isActiveCategory;
 

--- a/stories/picker/Behavior.stories.tsx
+++ b/stories/picker/Behavior.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/react';
 import React from 'react';
 
-import EmojiPicker, { Props } from '../../src';
+import EmojiPicker, { Categories, Props } from '../../src';
 import { SuggestionMode } from '../../src/types/exposedTypes';
 import { Template } from '../utils/pickerStoryUtils';
 
@@ -30,4 +30,13 @@ export const RecentlyUsed = (args: Props) => (
 
 export const LazyLoaded = (args: Props) => (
   <Template {...args} lazyLoadEmojis={true} />
+);
+
+export const SingleCategory = (args: Props) => (
+  <Template
+    {...args}
+    categories={[
+      { category: Categories.SMILEYS_PEOPLE, name: 'Smileys & People' },
+    ]}
+  />
 );

--- a/test/components/CategoryNavigation.test.tsx
+++ b/test/components/CategoryNavigation.test.tsx
@@ -117,6 +117,18 @@ describe('CategoryNavigation', () => {
     (useShouldHideCustomEmojis as any).mockReturnValue(true);
 
     const { container } = render(<CategoryNavigation />);
-    expect(container.firstChild).toBeEmptyDOMElement();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when only one category is visible', () => {
+    (useCategoriesConfig as any).mockReturnValue([
+      { category: Categories.SMILEYS_PEOPLE, name: 'Smileys & People' },
+    ]);
+
+    const { container, queryByRole } = render(<CategoryNavigation />);
+    expect(container.firstChild).toBeNull();
+    expect(
+      queryByRole('tablist', { name: 'Category navigation' }),
+    ).toBeNull();
   });
 });

--- a/test/emoji-picker-react.test.tsx
+++ b/test/emoji-picker-react.test.tsx
@@ -149,6 +149,25 @@ describe('EmojiPicker', () => {
     expect(onSkinToneChange).toHaveBeenCalledWith(SkinTones.MEDIUM);
   });
 
+  it('hides category navigation when only one category is configured', async () => {
+    renderPicker({
+      categories: [
+        {
+          name: 'Smileys & People',
+          category: Categories.SMILEYS_PEOPLE,
+        },
+      ],
+    });
+
+    expect(
+      screen.queryByRole('tablist', { name: 'Category navigation' }),
+    ).toBeNull();
+    // Emojis themselves still render.
+    expect(
+      await screen.findAllByLabelText('grinning face'),
+    ).not.toHaveLength(0);
+  });
+
   it('hides search when searchDisabled is set', () => {
     renderPicker({ searchDisabled: true });
 


### PR DESCRIPTION
A single tab navigates nowhere, yet the bar (with its header padding) always rendered — wasting space when only one category is configured.\n\n- `CategoryNavigation` now returns `null` when at most one category is visible (same hidden-custom counting as the render path, so no new props or APIs)\n- Zero-visible case (e.g. only a hidden custom category) also renders nothing instead of an empty padded bar\n\nTests: extended `CategoryNavigation.test.tsx` (single-category renders nothing; hidden-custom asserts null) + end-to-end case in `emoji-picker-react.test.tsx` reproducing the issue's config.\n\nVerified: 21 files / 95 tests pass, `tsc --noEmit` clean.\n\nCloses #396.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Category navigation is now hidden when only one or no categories are visible.
  * Custom categories are correctly hidden when configured to be excluded.
  * Emoji buttons remain available when category navigation is hidden.

* **Tests**
  * Added coverage for single-category pickers and hidden custom categories.
  * Added a usage example demonstrating a picker with a single category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->