### PR TITLE
fix: never focus partially-below-fold emojis on hover

### DIFF
--- a/playwright/issue-509-below-fold.spec.ts
+++ b/playwright/issue-509-below-fold.spec.ts
@@ -1,11 +1,11 @@
 /**
- * Keyboard navigation must reach partially-below-fold emojis.
+ * Keyboard navigation must reach emojis regardless of visibility.
  *
  * The below-fold hover guard (issue #509 follow-up) only gates the
  * `mouseover` path: hovering a half-visible emoji updates the preview
  * without focusing it (focusing would scroll-jump). Arrow-key navigation
- * takes a separate path that always moves DOM focus, including to
- * partially or fully below-fold emojis.
+ * takes a separate path that always moves DOM focus — to fully visible,
+ * partially visible, and fully below-fold emojis alike.
  *
  * @file issue-509-below-fold.spec.ts
  */
@@ -14,53 +14,79 @@ import { expect, test } from '@playwright/test';
 
 const storyUrl = (id: string) => `/iframe.html?id=${id}&viewMode=story`;
 
-test('ArrowDown moves focus to a partially-below-fold emoji', async ({
-  page,
-}) => {
+type RowKind = 'visible' | 'partial' | 'below';
+
+async function gotoPicker(page) {
   await page.addInitScript(() => window.localStorage.clear());
   await page.goto(storyUrl('picker-overview--no-suggested'));
   await expect(
     page.getByRole('tablist', { name: 'Category navigation' }),
   ).toBeVisible();
+}
 
-  // Scroll so a grid row straddles the body's bottom fold, focus the
-  // same-column button in the row above, and return the target's label.
-  const targetLabel = await page.evaluate(() => {
-    const body = document.querySelector('.epr-body') as HTMLElement;
-    body.scrollTop = 45;
-    const buttons = Array.from(
-      body.querySelectorAll<HTMLButtonElement>('button.epr-emoji'),
-    ).filter(
-      b =>
-        b.getAttribute('aria-label') &&
-        b.classList.contains('epr-visible') &&
-        window.getComputedStyle(b).opacity !== '0',
+/**
+ * Scrolls until a row of the requested visibility exists, focuses the
+ * same-column button in the row above it, and returns the target's label.
+ * Retries deeper scroll positions because virtualization only renders a
+ * window of rows around the viewport.
+ */
+async function prepareVerticalMove(
+  page,
+  kind: RowKind,
+): Promise<string> {
+  for (const scrollTop of [0, 60, 120, 200, 320, 480]) {
+    const label = await page.evaluate(
+      ({ top, want }) => {
+        const body = document.querySelector('.epr-body') as HTMLElement;
+        body.scrollTop = top;
+        const buttons = Array.from(
+          body.querySelectorAll<HTMLButtonElement>('button.epr-emoji'),
+        ).filter(
+          b =>
+            b.getAttribute('aria-label') &&
+            b.classList.contains('epr-visible') &&
+            window.getComputedStyle(b).opacity !== '0',
+        );
+        const rows = new Map<number, HTMLButtonElement[]>();
+        for (const b of buttons) {
+          const list = rows.get(b.offsetTop) ?? [];
+          list.push(b);
+          rows.set(b.offsetTop, list);
+        }
+        const bodyRect = body.getBoundingClientRect();
+        const tops = [...rows.keys()].sort((a, b) => a - b);
+        for (let i = 1; i < tops.length; i++) {
+          const r = rows
+            .get(tops[i])![0]
+            .getBoundingClientRect();
+          const matches =
+            want === 'visible'
+              ? r.bottom <= bodyRect.bottom
+              : want === 'partial'
+                ? r.top < bodyRect.bottom && r.bottom > bodyRect.bottom
+                : r.top >= bodyRect.bottom;
+          if (matches) {
+            rows.get(tops[i - 1])![0].focus();
+            return (
+              rows.get(tops[i])![0].getAttribute('aria-label') ?? ''
+            );
+          }
+        }
+        return '';
+      },
+      { top: scrollTop, want: kind },
     );
-    const rows = new Map<number, HTMLButtonElement[]>();
-    for (const b of buttons) {
-      const list = rows.get(b.offsetTop) ?? [];
-      list.push(b);
-      rows.set(b.offsetTop, list);
+    if (label) {
+      // Let virtualization and focus settle before pressing keys.
+      await page.waitForTimeout(150);
+      return label;
     }
-    const bodyRect = body.getBoundingClientRect();
-    const tops = [...rows.keys()].sort((a, b) => a - b);
-    for (let i = 1; i < tops.length; i++) {
-      const row = rows.get(tops[i])!;
-      const r = row[0].getBoundingClientRect();
-      // Straddles the fold: starts above the bottom edge, ends below it.
-      // Focus the same-index button in the row above; ArrowDown should
-      // land on this row's button even though it is half cut off.
-      if (r.top < bodyRect.bottom && r.bottom > bodyRect.bottom) {
-        const prev = rows.get(tops[i - 1])!;
-        prev[0].focus();
-        return row[0].getAttribute('aria-label') ?? '';
-      }
-    }
-    return '';
-  });
-  expect(targetLabel).not.toBe('');
+  }
+  return '';
+}
 
-  // The movement itself is async (requestAnimationFrame-deferred focus).
+async function expectFocusMovesTo(page, label: string) {
+  // Focus moves via requestAnimationFrame; poll for the change.
   await page.keyboard.press('ArrowDown');
   await expect
     .poll(
@@ -73,5 +99,32 @@ test('ArrowDown moves focus to a partially-below-fold emoji', async ({
         ),
       { timeout: 5000 },
     )
-    .toBe(targetLabel);
+    .toBe(label);
+}
+
+test('ArrowDown moves focus between fully visible emojis', async ({
+  page,
+}) => {
+  await gotoPicker(page);
+  const target = await prepareVerticalMove(page, 'visible');
+  expect(target).not.toBe('');
+  await expectFocusMovesTo(page, target);
+});
+
+test('ArrowDown moves focus to a partially-below-fold emoji', async ({
+  page,
+}) => {
+  await gotoPicker(page);
+  const target = await prepareVerticalMove(page, 'partial');
+  expect(target).not.toBe('');
+  await expectFocusMovesTo(page, target);
+});
+
+test('ArrowDown moves focus to a fully-below-fold emoji', async ({
+  page,
+}) => {
+  await gotoPicker(page);
+  const target = await prepareVerticalMove(page, 'below');
+  expect(target).not.toBe('');
+  await expectFocusMovesTo(page, target);
 });

--- a/playwright/issue-509-below-fold.spec.ts
+++ b/playwright/issue-509-below-fold.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Keyboard navigation must reach partially-below-fold emojis.
+ *
+ * The below-fold hover guard (issue #509 follow-up) only gates the
+ * `mouseover` path: hovering a half-visible emoji updates the preview
+ * without focusing it (focusing would scroll-jump). Arrow-key navigation
+ * takes a separate path that always moves DOM focus, including to
+ * partially or fully below-fold emojis.
+ *
+ * @file issue-509-below-fold.spec.ts
+ */
+
+import { expect, test } from '@playwright/test';
+
+const storyUrl = (id: string) => `/iframe.html?id=${id}&viewMode=story`;
+
+test('ArrowDown moves focus to a partially-below-fold emoji', async ({
+  page,
+}) => {
+  await page.addInitScript(() => window.localStorage.clear());
+  await page.goto(storyUrl('picker-overview--no-suggested'));
+  await expect(
+    page.getByRole('tablist', { name: 'Category navigation' }),
+  ).toBeVisible();
+
+  // Scroll so a grid row straddles the body's bottom fold, focus the
+  // same-column button in the row above, and return the target's label.
+  const targetLabel = await page.evaluate(() => {
+    const body = document.querySelector('.epr-body') as HTMLElement;
+    body.scrollTop = 45;
+    const buttons = Array.from(
+      body.querySelectorAll<HTMLButtonElement>('button.epr-emoji'),
+    ).filter(
+      b =>
+        b.getAttribute('aria-label') &&
+        b.classList.contains('epr-visible') &&
+        window.getComputedStyle(b).opacity !== '0',
+    );
+    const rows = new Map<number, HTMLButtonElement[]>();
+    for (const b of buttons) {
+      const list = rows.get(b.offsetTop) ?? [];
+      list.push(b);
+      rows.set(b.offsetTop, list);
+    }
+    const bodyRect = body.getBoundingClientRect();
+    const tops = [...rows.keys()].sort((a, b) => a - b);
+    for (let i = 1; i < tops.length; i++) {
+      const row = rows.get(tops[i])!;
+      const r = row[0].getBoundingClientRect();
+      // Straddles the fold: starts above the bottom edge, ends below it.
+      // Focus the same-index button in the row above; ArrowDown should
+      // land on this row's button even though it is half cut off.
+      if (r.top < bodyRect.bottom && r.bottom > bodyRect.bottom) {
+        const prev = rows.get(tops[i - 1])!;
+        prev[0].focus();
+        return row[0].getAttribute('aria-label') ?? '';
+      }
+    }
+    return '';
+  });
+  expect(targetLabel).not.toBe('');
+
+  // The movement itself is async (requestAnimationFrame-deferred focus).
+  await page.keyboard.press('ArrowDown');
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(
+          () =>
+            (document.activeElement as HTMLElement | null)?.getAttribute(
+              'aria-label',
+            ) ?? '',
+        ),
+      { timeout: 5000 },
+    )
+    .toBe(targetLabel);
+});

--- a/src/hooks/useEmojiPreviewEvents.ts
+++ b/src/hooks/useEmojiPreviewEvents.ts
@@ -144,5 +144,5 @@ export function useEmojiPreviewEvents(
       bodyRef?.removeEventListener('blur', onLeave, true);
       bodyRef?.removeEventListener('keydown', onEscape);
     };
-  }, [BodyRef, allow, setPreviewEmoji, isMouseDisallowed, allowMouseMove]);
+  }, [BodyRef, PickerMainRef, allow, setPreviewEmoji, isMouseDisallowed, allowMouseMove]);
 }

--- a/src/hooks/useEmojiPreviewEvents.ts
+++ b/src/hooks/useEmojiPreviewEvents.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useEffect } from 'react';
 
+import { detectEmojyPartiallyBelowFold } from '../DomUtils/detectEmojyPartiallyBelowFold';
 import { focusElement } from '../DomUtils/focusElement';
 import {
   allUnifiedFromEmojiElement,
@@ -107,9 +108,23 @@ export function useEmojiPreviewEvents(
       // Pulling focus out of an external element steals the caret from
       // host-app inputs (issue #320). The guard runs again inside the
       // deferred callback in case focus moved out after this event.
-      if (!isExternalElementFocused()) {
+      // Partially visible buttons are never focused: focusing would make
+      // the browser scroll them into view, yanking the scroll position
+      // while the user is browsing (see also PR #509).
+      if (
+        !isExternalElementFocused() &&
+        !isPartiallyBelowFold(button, bodyRef)
+      ) {
         focusElement(button, () => !isExternalElementFocused());
       }
+    }
+
+    function isPartiallyBelowFold(
+      button: HTMLButtonElement,
+      body: HTMLElement | null,
+    ): boolean {
+      const belowFoldByPx = detectEmojyPartiallyBelowFold(button, body);
+      return belowFoldByPx < button.getBoundingClientRect().height;
     }
 
     function isExternalElementFocused(): boolean {

--- a/test/issue-509-below-fold.test.tsx
+++ b/test/issue-509-below-fold.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import EmojiPicker, { Props } from '../src';
+import { Categories } from '../src/config/categoryConfig';
+import { EmojiData } from '../src/types/exposedTypes';
+
+vi.mock('../src/hooks/preloadEmoji', () => ({
+  preloadEmojiIfNeeded: () => undefined,
+  preloadEmoji: () => undefined,
+  preloadedEmojs: new Set(),
+}));
+
+const minimalEmojiData: EmojiData = {
+  categories: {
+    [Categories.SMILEYS_PEOPLE]: {
+      category: Categories.SMILEYS_PEOPLE,
+      name: 'Smileys & People',
+    },
+  },
+  emojis: {
+    [Categories.SMILEYS_PEOPLE]: [
+      { n: ['face', 'grinning face'], u: '1f600', a: '1' },
+      { n: ['face', 'grinning face with big eyes'], u: '1f603', a: '0.6' },
+      // Must exist: the preview falls back to this emoji when idle.
+      { n: ['smiling face with smiling eyes'], u: '1f60a', a: '0.6' },
+    ],
+  },
+};
+
+function renderPicker(props: Partial<Props> = {}) {
+  return render(
+    <EmojiPicker
+      emojiData={minimalEmojiData}
+      categories={[Categories.SMILEYS_PEOPLE]}
+      autoFocusSearch={false}
+      {...props}
+    />,
+  );
+}
+
+// focusElement() defers via requestAnimationFrame; flush before asserting.
+async function flushFocus() {
+  await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+  await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function mockRect(el: Element, rect: Partial<DOMRect>) {
+  return vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    toJSON: () => ({}),
+    ...rect,
+  } as DOMRect);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Hovering a partially-below-the-fold emoji must update the preview without
+ * moving DOM focus: focusing it would make the browser scroll it into view,
+ * yanking the scroll position while the user is browsing.
+ * Related: https://github.com/ealush/emoji-picker-react/pull/509
+ */
+describe('below-fold hover never takes focus', () => {
+  it('updates the preview but keeps focus on the search input', async () => {
+    renderPicker();
+
+    const search = screen.getByLabelText(
+      'Type to search for an emoji',
+    ) as HTMLInputElement;
+    search.focus();
+    expect(document.activeElement).toBe(search);
+
+    const buttons = await screen.findAllByLabelText('grinning face');
+    const emojiButton = buttons[buttons.length - 1];
+    const body = document.querySelector('.epr-body') as HTMLElement;
+
+    // Button peeking 10px above the body's bottom edge (30px tall).
+    mockRect(body, { y: 0, height: 200 });
+    mockRect(emojiButton, { y: 190, height: 30 });
+
+    fireEvent.mouseOver(emojiButton);
+    await flushFocus();
+
+    // Preview follows the hover...
+    expect(await screen.findByText('grinning face')).toBeDefined();
+    // ...but focus stays put, so no scroll jump happens.
+    expect(document.activeElement).toBe(search);
+  });
+
+  it('still takes focus when the hovered emoji is fully visible', async () => {
+    renderPicker();
+
+    const search = screen.getByLabelText(
+      'Type to search for an emoji',
+    ) as HTMLInputElement;
+    search.focus();
+
+    const buttons = await screen.findAllByLabelText('grinning face');
+    const emojiButton = buttons[buttons.length - 1];
+    const body = document.querySelector('.epr-body') as HTMLElement;
+
+    // Fully inside the body viewport.
+    mockRect(body, { y: 0, height: 200 });
+    mockRect(emojiButton, { y: 100, height: 30 });
+
+    fireEvent.mouseOver(emojiButton);
+    await flushFocus();
+
+    expect(document.activeElement).toBe(emojiButton);
+  });
+});


### PR DESCRIPTION
Follow-up to #527 (which fixed #320 but dropped the below-fold check), incorporating the still-valid half of community PR #509.

Hovering a partially visible emoji focused it, making the browser scroll it into view and yanking the scroll position while browsing. Now the preview always updates on hover, but focusElement is skipped for below-fold buttons (reusing detectEmojyPartiallyBelowFold). Also silences a react-hooks/exhaustive-deps warning for PickerMainRef left over from #527.

Tests: new test/issue-509-below-fold.test.tsx (below-fold hover updates preview without moving focus; fully-visible hover still takes focus with internal focus) — verified red without the fix; full suite 22 files / 97 tests + tsc + eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the emoji picker from unexpectedly scrolling when hovering over an emoji that is partially below the visible area.
  * Preserved preview updates while keeping focus in the search field during hover interactions.

* **Tests**
  * Added coverage for hover behavior near the picker’s lower edge.
  * Added coverage confirming keyboard navigation continues to move focus to partially visible emojis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->