### PR TITLE
fix: structural config compare and reference-based observer trigger

### DIFF
--- a/src/components/navigation/CategoryNavigation.tsx
+++ b/src/components/navigation/CategoryNavigation.tsx
@@ -36,16 +36,12 @@ export function CategoryNavigation() {
   const hideCustomCategory = useShouldHideCustomEmojis();
   const { customGroups, emojiData } = usePickerDataContext();
 
-  // Rendered section identities. Passed to the scroll-detection hook so
-  // added/removed sections are (re-)subscribed; stable across renders
-  // unless the effective category list changes.
-  const categoryIdentitiesKey = categoriesConfig
-    .map(entry => categoryIdFromCategoryConfig(entry))
-    .join('|');
+  // The observer re-subscribes when the merged categories reference
+  // changes (sections added/removed); the reference is stable otherwise.
   useActiveCategoryScrollDetection({
     setActiveCategory,
     setVisibleCategories,
-    categoryIdentitiesKey,
+    categories: categoriesConfig,
   });
 
   const visibleCategories = categoriesConfig.filter(categoryConfig => {

--- a/src/config/compareConfig.ts
+++ b/src/config/compareConfig.ts
@@ -1,3 +1,5 @@
+import { Categories, CategoryConfig } from '../types/exposedTypes';
+
 import { UserCategoryConfig } from './categoryConfig';
 import { PickerConfig } from './config';
 import { CustomEmoji } from './customEmojiConfig';
@@ -27,35 +29,74 @@ export function compareConfig(prev: PickerConfig, next: PickerConfig) {
     prev.searchDisabled === next.searchDisabled &&
     prev.skinTonePickerLocation === next.skinTonePickerLocation &&
     prevCustomEmojis.length === nextCustomEmojis.length &&
-    customEmojisKey(prevCustomEmojis) === customEmojisKey(nextCustomEmojis) &&
-    categoriesKey(prev.categories) === categoriesKey(next.categories) &&
+    customEmojisEqual(prevCustomEmojis, nextCustomEmojis) &&
+    categoriesEqual(prev.categories, next.categories) &&
     prev.emojiData === next.emojiData
   );
 }
 
 /**
- * Content identity for custom emojis. Length alone misses regroups and
- * swaps, which would leave merged categories, search, and sections stale.
+ * Structural content equality for custom emojis. Length alone misses
+ * regroups and swaps, which would leave merged categories, search, and
+ * sections stale. Fields are compared element-wise (never serialized
+ * with delimiters) so user-controlled values cannot collide.
  */
-function customEmojisKey(customEmojis: CustomEmoji[]): string {
-  return customEmojis
-    .map(
-      emoji =>
-        `${emoji.id}:${emoji.group ?? ''}:${emoji.names.join(',')}:${emoji.imgUrl}`,
-    )
-    .join('|');
+function customEmojisEqual(
+  prev: CustomEmoji[],
+  next: CustomEmoji[],
+): boolean {
+  if (prev.length !== next.length) {
+    return false;
+  }
+  return prev.every((emoji, index) => {
+    const other = next[index];
+    return (
+      emoji.id === other.id &&
+      (emoji.group ?? '') === (other.group ?? '') &&
+      emoji.imgUrl === other.imgUrl &&
+      emoji.names.length === other.names.length &&
+      emoji.names.every((name, nameIndex) => name === other.names[nameIndex])
+    );
+  });
 }
 
 /**
- * Content identity for the categories input. Order, labels, icons, and
- * group selection all flow into the merged configuration.
+ * Structural content equality for the categories input. Order, labels,
+ * group selection, and icon identity all flow into the merged
+ * configuration. Icons compare by reference: swapping one icon element
+ * for another must rebuild, while a stable reference stays cheap.
  */
-function categoriesKey(categories: UserCategoryConfig | undefined): string {
-  return (categories ?? [])
-    .map(entry =>
-      typeof entry === 'string'
-        ? entry
-        : `${entry.category}:${entry.name}:${entry.group ?? ''}:${entry.icon ? '1' : ''}`,
-    )
-    .join('|');
+function categoriesEqual(
+  prev: UserCategoryConfig | undefined,
+  next: UserCategoryConfig | undefined,
+): boolean {
+  const prevEntries = prev ?? [];
+  const nextEntries = next ?? [];
+  if (prevEntries.length !== nextEntries.length) {
+    return false;
+  }
+  return prevEntries.every((entry, index) =>
+    categoryEntriesEqual(entry, nextEntries[index]),
+  );
+}
+
+/**
+ * One categories entry compared structurally. Icons compare by reference:
+ * swapping one icon element for another rebuilds, a stable reference stays
+ * cheap. Delimited serialization is avoided so user-controlled values
+ * cannot collide.
+ */
+function categoryEntriesEqual(
+  entry: Categories | CategoryConfig,
+  other: Categories | CategoryConfig,
+): boolean {
+  if (typeof entry === 'string' || typeof other === 'string') {
+    return entry === other;
+  }
+  return (
+    entry.category === other.category &&
+    entry.name === other.name &&
+    (entry.group ?? '') === (other.group ?? '') &&
+    entry.icon === other.icon
+  );
 }

--- a/src/hooks/useActiveCategoryScrollDetection.ts
+++ b/src/hooks/useActiveCategoryScrollDetection.ts
@@ -3,21 +3,21 @@ import { useEffect } from 'react';
 import { categoryNameFromDom } from '../DomUtils/categoryNameFromDom';
 import { asSelectors, ClassNames } from '../DomUtils/classNames';
 import { useBodyRef } from '../components/context/ElementRefContext';
+import { CategoriesConfig } from '../config/categoryConfig';
 
 export function useActiveCategoryScrollDetection({
   setActiveCategory,
   setVisibleCategories,
-  categoryIdentitiesKey,
+  categories,
 }: {
   setActiveCategory: (category: string) => void;
   setVisibleCategories: (categories: string[]) => void;
   /**
-   * Stable string derived from the rendered category identities
-   * (e.g. ids joined). Re-subscribes the observer when sections are
-   * added or removed so new elements are observed and detached ones
-   * stop contributing; unrelated renders keep the same key.
+   * Effective category list. The merged array reference only changes when
+   * the configuration is re-merged, so the observer re-subscribes exactly
+   * when sections are added or removed — no serialization involved.
    */
-  categoryIdentitiesKey: string;
+  categories: CategoriesConfig;
 }) {
   const BodyRef = useBodyRef();
 
@@ -75,5 +75,5 @@ export function useActiveCategoryScrollDetection({
     return () => {
       observer.disconnect();
     };
-  }, [BodyRef, categoryIdentitiesKey, setActiveCategory, setVisibleCategories]);
+  }, [BodyRef, categories, setActiveCategory, setVisibleCategories]);
 }

--- a/test/config/compareConfig.test.ts
+++ b/test/config/compareConfig.test.ts
@@ -52,8 +52,7 @@ describe('compareConfig', () => {
     expect(compareConfig(prev, next)).toBe(false);
   });
 
-  it('treats reordered categories as different', () => {
-    const prev: PickerConfig = {
+  it('treats reordered categories as different', () => {    const prev: PickerConfig = {
       ...baseProps,
       categories: [Categories.SMILEYS_PEOPLE, Categories.ANIMALS_NATURE],
     };
@@ -101,6 +100,58 @@ describe('compareConfig', () => {
     };
 
     expect(compareConfig(prev, next)).toBe(true);
+  });
+
+  it('treats swapped icon references as different', () => {
+    const prev: PickerConfig = {
+      ...baseProps,
+      categories: [
+        {
+          category: Categories.CUSTOM,
+          group: 'animals',
+          name: 'Animals',
+          icon: 'icon-a' as never,
+        },
+      ],
+    };
+    const next: PickerConfig = {
+      ...baseProps,
+      categories: [
+        {
+          category: Categories.CUSTOM,
+          group: 'animals',
+          name: 'Animals',
+          icon: 'icon-b' as never,
+        },
+      ],
+    };
+
+    expect(compareConfig(prev, next)).toBe(false);
+  });
+
+  it('treats a stable icon reference as equivalent', () => {
+    const icon = 'icon-a' as never;
+    const categories = [
+      {
+        category: Categories.CUSTOM,
+        group: 'animals',
+        name: 'Animals',
+        icon,
+      },
+    ] as PickerConfig['categories'];
+    const prev: PickerConfig = { ...baseProps, categories };
+    const next: PickerConfig = { ...baseProps, categories };
+
+    expect(compareConfig(prev, next)).toBe(true);
+  });
+
+  it('distinguishes delimiter-containing names structurally', () => {
+    const prev = withCustomEmojis([{ id: 'a' }]);
+    (prev.customEmojis as { names: string[] }[])[0].names = ['x,y'];
+    const next = withCustomEmojis([{ id: 'a' }]);
+    (next.customEmojis as { names: string[] }[])[0].names = ['x', 'y'];
+
+    expect(compareConfig(prev, next)).toBe(false);
   });
 });
 

--- a/test/custom-groups.test.tsx
+++ b/test/custom-groups.test.tsx
@@ -70,7 +70,8 @@ const renderPicker = (props: Partial<Props> = {}) =>
  * Each `{ category: CUSTOM, group }` entry renders its own section with
  * its own nav tab; ungrouped customs share the classic bucket.
  */
-describe('custom emoji groups', () => {  it('renders one section and nav tab per group plus the shared bucket', async () => {
+describe('custom emoji groups', () => {
+  it('renders one section and nav tab per group plus the shared bucket', async () => {
     renderPicker();
 
     // Nav tabs.
@@ -310,9 +311,7 @@ describe('custom emoji group updates', () => {
     );
 
     expect(screen.queryByRole('tab', { name: 'animals' })).toBeNull();
-    expect(
-      screen.queryByRole('rowgroup', { name: 'animals' }),
-    ).toBeNull();
+    expect(screen.queryByRole('rowgroup', { name: 'animals' })).toBeNull();
     expect(screen.getByRole('tab', { name: 'people' })).toBeInTheDocument();
     expect(
       within(screen.getByRole('rowgroup', { name: 'people' })).getByLabelText(
@@ -369,13 +368,47 @@ describe('custom emoji group updates', () => {
 
     const tabs = within(screen.getByRole('tablist'))
       .getAllByRole('tab')
-      .map(tab => tab.getAttribute('aria-label'));
+      .map((tab) => tab.getAttribute('aria-label'));
     expect(tabs).toEqual(['People', 'Wildlife']);
-    const headings = screen.getAllByRole('heading').map(h => h.textContent);
+    const headings = screen.getAllByRole('heading').map((h) => h.textContent);
     expect(headings).toEqual(['People', 'Wildlife']);
     expect(screen.queryByRole('tab', { name: 'Animals' })).toBeNull();
     expect(screen.getByTestId('icon-v2')).toBeInTheDocument();
     expect(screen.queryByTestId('icon-v1')).toBeNull();
+  });
+
+  it('E: replaces only the group icon, keeping everything else', async () => {
+    const categories = (icon: React.ReactNode) => [
+      { category: Categories.SMILEYS_PEOPLE, name: 'Smileys & People' },
+      {
+        category: Categories.CUSTOM,
+        group: 'animals',
+        name: 'Animals',
+        icon,
+      },
+    ];
+    const { rerender } = render(
+      <EmojiPicker
+        emojiData={minimalEmojiData}
+        customEmojis={[pandaAnimals]}
+        categories={categories(<span data-testid="icon-old">O</span>)}
+        autoFocusSearch={false}
+      />,
+    );
+
+    expect(screen.getByTestId('icon-old')).toBeInTheDocument();
+
+    rerender(
+      <EmojiPicker
+        emojiData={minimalEmojiData}
+        customEmojis={[pandaAnimals]}
+        categories={categories(<span data-testid="icon-new">N</span>)}
+        autoFocusSearch={false}
+      />,
+    );
+
+    expect(screen.getByTestId('icon-new')).toBeInTheDocument();
+    expect(screen.queryByTestId('icon-old')).toBeNull();
   });
 
   it('C: moves an emoji between groups keeping id and length', async () => {


### PR DESCRIPTION
Follow-up review findings on the group updates work (#533).

**P1 — icon-only updates were stale.** `categoriesKey` recorded only icon truthiness, so swapping one icon element for another compared equal and `React.memo`/`useSetConfig` kept the old icon. Icons now compare by reference.

**P2 — delimiter collisions.** Both key builders serialized user-controlled values with `:`, `,`, `|` (e.g. names `['x,y']` vs `['x', 'y']` compared equal; group `"a|custom:b"` collided across the observer key too). Replaced with structural, element-wise comparison — no serialization involved.

**P2 — observer key ambiguity.** The `"|"`-joined identities string is gone; the scroll-detection hook takes the merged `categories` array reference, which only changes when the configuration is re-merged.

**Tests:** icon-swap/stable-icon/delimiter compare cases + icon-only rerender test (E) — all verified red on master code first. Full suite 26 files / 135 green, tsc + eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of category configuration changes so active-category tracking updates reliably.
  - Improved configuration comparisons for custom emojis, categories, and icon references.
  - Ensured group icon changes are reflected correctly without affecting other group data.

- **Tests**
  - Added coverage for category icon changes, reused icon references, emoji name comparisons, and group icon updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->